### PR TITLE
Retrieve cleaning status from API

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,16 +399,6 @@ XiaomiRoborockVacuum.prototype = {
 
                 // STATE
                 log.debug('DEB getDevice | Initializing status values to variables');
-                that.cleaning = state.cleaning;
-                that.charging = state.charging;
-                that.docked = state.charging;
-                that.speed = state.fanSpeed;
-                that.battery = state.batteryLevel;
-                if(state.cleaning == true) {
-                    that.pausepossible = true;
-                } else {
-                    that.pausepossible = false;
-                }
                 that.lastrobotcleaning = undefined;
                 that.lastrobotcharging = undefined;
                 that.lastspeed = undefined;
@@ -433,6 +423,12 @@ XiaomiRoborockVacuum.prototype = {
     getState: function() {
         var that = this;
         var log = that.log;
+
+        if (!that.device) {
+            log.error('ERR getState | No vacuum cleaner is discovered.');
+            callback(new Error('ERR getState | No vacuum cleaner is discovered.'));
+            return;
+        }
 
         return that.device.state().then(state => {
             state = JSON.parse(JSON.stringify(state)); // Convert in valid JSON


### PR DESCRIPTION
Hi! Based on your comments in the issue #36 I thought I could help.

I've been going through the code and I think we can do some improvements :)

I believe the MIIO API returns promises and we could make better use of them. Most the current usage is just calling them but not awaiting for it's result (just catching and logging).

As a starter, I've made use of the method https://github.com/aholstenson/miio/blob/master/docs/devices/vacuum.md#check-if-cleaning to get if cleaning is happening (instead of relying on the local variable `this.cleaning`).
I'm also returning the promises `that.device.activateCleaning()` and `that.device.activateCharging()` to catch any error that may occur when starting/stopping the cleaning. 

If we find that's always related to sudden disconnections, we might be able to create a `reconnect` method that will reinstantiate the device (kind of like removing the listeners from `that.device` and then calling `that.getDevice()`) and then retry the action we've asked it to do.
If we find it gets to reconnect automatically, we can just retry the request after a couple of seconds.

I'm currently testing these changes at home. If it works fine (and you are happy with that, I might revisit all the get/set methods to use the API instead of using the internal property of the class.

Also, as the owner of this project, I'd like to ask you: 
What version of the NodeJS we want to support? The reason I'm asking is:
1. We can use a proper implementation of classes and arrow functions since NodeJS v4
2. We can use async/await since NodeJS v8. That'll make the promise handling much easier:
```
// "Normal" promise implementation
return doOneThing()
  .then((result1) => doAnotherThing(result1));

// With async/await
const result1 = await doOneThing();
await doAnotherThing(result1);
```

Hopefully we'll get this bullet proof :)