### PR TITLE
 Controlled Connection Retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -390,12 +390,12 @@ class XiaomiRoborockVacuum {
 
   async connect() {
     if (this.connectingPromise === null) { // if already trying to connect, don't trigger yet another one
-      this.connectingPromise = this.initializeDevice().catch((err) => {
+      this.connectingPromise = this.initializeDevice().catch((error) => {
         this.log.error(`ERR connect | miio.device, next try in 2 minutes | ${error}`);
         clearTimeout(this.connectRetry);
         // Using setTimeout instead of holding the promise. This way we'll keep retrying but not holding the other actions
         this.connectRetry = setTimeout(() => this.connect(), 120000);
-        throw err;
+        throw error;
       });
     }
     try {

--- a/index.js
+++ b/index.js
@@ -420,7 +420,6 @@ class XiaomiRoborockVacuum {
       this.log.debug(`DEB ensureDevice | ${this.model} | The socket is still on. Reusing it.`);
     } catch (err) {
       if (/destroyed/i.test(err.message) || /No vacuum cleaner is discovered yet/.test(err.message)) {
-        this.device = null;
         this.log.info(`INF ensureDevice | ${this.model} | The socket was destroyed or not initialised, initialising the device`);
         await this.connect();
       } else {

--- a/index.js
+++ b/index.js
@@ -401,6 +401,8 @@ class XiaomiRoborockVacuum {
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
+    // We have exhausted the number of retries, throw connection error
+    throw Error(`Failed to connect after ${maxTries} attempts!`);
   }
 
   async connect(maxTries, delay) {


### PR DESCRIPTION
> If you start / restart the Homebridge and the Xiaomi is off / battery is empty - then the plugin can not reach the robot.
> It comes: "ERR connect | miio.device, next try in 2 minutes | Error: Could not connect to device, handshake timeout“ show here line 402.

> Because the Homebridge does not get a Return / Error from homebridge-xiaomi-roborock-vacuum, the Homebridge hangs when the plugin is loaded and no devices in the Homebridge are accessible. In the Apple Home app, all devices from this Homebridge display "No Answer" or "Refresh“.

Instead of hanging forever until the device is connected, I've moved the retries to a setTimeout. That way the promise will either resolve or reject straight away. But we'll keep a retry to connect on every 2 minutes.

Still, whenever there's a new GET/SET request from HomeKit while still disconnected, it will try to connect again. Applying the same behaviour of resolving/rejecting the promise after the first attempt and schedule a reconnection attempt for later.