### PR TITLE
fix roborock.vacuum.t6 fanSpeed not supported issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ class XiaomiRoborockVacuum {
       'roborock.vacuum.c1': XiaomiRoborockVacuum.speedmodes_gen1,
       'roborock.vacuum.s5': XiaomiRoborockVacuum.speedmodes_gen2,
       'roborock.vacuum.s6': XiaomiRoborockVacuum.speedmodes_gen3,
+      'roborock.vacuum.t6': XiaomiRoborockVacuum.speedmodes_gen3,
     }
   }
 


### PR DESCRIPTION
fanSpeed map is correct, but missing vacuum mode for roborock.vacuum.t6,
so it can't find this mode and use default XiaomiRoborockVacuum.speedmodes_gen1 fanSpeed map to continue.