### PR TITLE
Fix UnhandledPromiseRejectionWarning on startup when it fails to connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,9 @@ class XiaomiRoborockVacuum {
     this.initialiseServices();
 
     // Initialize device
-    this.connect();
+    this.connect().catch(() => {
+      // Do nothing in the catch because this function already logs the error internally and retries after 2 minutes.
+    });
   }
 
   initialiseServices() {


### PR DESCRIPTION
I reread the issue and better understood the logs you shared (thank you for that).

The error is that the method `this.connect()` in the `constructor` is rejecting a promise and there is no catch around it. Not anything awaiting the promise. This usually leads to the entire NodeJS process to crash. 

It's a simple solution. Simply adding an empty `catch` in the constructor because the method itself already tries to reconnect after 2 minutes.

Fixes #81 