### PR TITLE
Do not throw on state.error

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,10 +446,6 @@ class XiaomiRoborockVacuum {
 
     try {
       const state = await this.device.state();
-      if (state.error) {
-        this.changedError(state.error);
-        throw state.error;
-      }
 
       this.log.debug(`DEB getState | ${this.model} | State %j`, state);
 
@@ -458,8 +454,13 @@ class XiaomiRoborockVacuum {
       this.changedSpeed(state.fanSpeed);
       this.changedBattery(state.batteryLevel);
       this.changedPause(state.cleaning);
+      
+      if (state.error) {
+        this.changedError(state.error);
+        // No need to throw the error at this point. This are just warnings like (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/91)
+      }
     } catch (err) {
-      this.log.error(`ERR getState | this.device.state | ${err}`);
+      this.log.error(`ERR getState | this.device.state | %j`, err);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const miio = require('miio');
 const util = require('util');
 const callbackify = require('./lib/callbackify');
+const safeCall = require('./lib/safeCall');
 
 let homebrideAPI, Service, Characteristic;
 
@@ -446,19 +447,16 @@ class XiaomiRoborockVacuum {
 
     try {
       const state = await this.device.state();
-
       this.log.debug(`DEB getState | ${this.model} | State %j`, state);
 
-      this.changedCleaning(state.cleaning);
-      this.changedCharging(state.charging);
-      this.changedSpeed(state.fanSpeed);
-      this.changedBattery(state.batteryLevel);
-      this.changedPause(state.cleaning);
-      
-      if (state.error) {
-        this.changedError(state.error);
-        // No need to throw the error at this point. This are just warnings like (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/91)
-      }
+      safeCall(state.cleaning, (cleaning) => this.changedCleaning(cleaning));
+      safeCall(state.charging, (charging) => this.changedCharging(charging));
+      safeCall(state.fanSpeed, (fanSpeed) => this.changedSpeed(fanSpeed));
+      safeCall(state.batteryLevel, (batteryLevel) => this.changedBattery(batteryLevel));
+      safeCall(state.cleaning, (cleaning) => this.changedPause(cleaning));
+
+      // No need to throw the error at this point. This are just warnings like (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/91)
+      safeCall(state.error, (error) => this.changedError(error));
     } catch (err) {
       this.log.error(`ERR getState | this.device.state | %j`, err);
     }

--- a/lib/safeCall.js
+++ b/lib/safeCall.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Calls the function `fn` if `maybeValue` is not undefined
+ * 
+ * @param maybeValue The value that can be undefined
+ * @param fn The function to be called with the value as a parameter
+ */
+module.exports = async function (maybeValue, fn) {
+  if (typeof maybeValue !== 'undefined') {
+    return fn(maybeValue);
+  }
+}


### PR DESCRIPTION
Fixes #91 

Those errors seem to be controlled errors. More like warnings. Maybe it's better to simply log them (as we do now in the method `this.changedError` and to stop throwing it.

I'd love it if we can find a way (via Homebridge) to show the error notification in the Home app. That's something to investigate.