### PR TITLE
Add Start/Stop button when the pause button is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,13 @@ class XiaomiRoborockVacuum {
       .on('get', (cb) => callbackify(() => this.getBatteryLow(), cb));
 
     if (this.config.pause) {
-      this.services.pause = new Service.Switch(`${this.config.name} Pause`);
+      this.services.fanSwitch = new Service.Switch(this.config.name, 'ON/OFF');
+      this.services.fanSwitch
+        .getCharacteristic(Characteristic.On)
+        .on('get', (cb) => callbackify(() => this.getCleaning(), cb))
+        .on('set', (newState, cb) => callbackify(() => this.setCleaning(newState), cb));
+
+      this.services.pause = new Service.Switch(`${this.config.name} Pause`, 'Pause');
       this.services.pause
         .getCharacteristic(Characteristic.On)
         .on('get', (cb) => callbackify(() => this.getPauseState(), cb))
@@ -323,6 +329,7 @@ class XiaomiRoborockVacuum {
         this.log.info(`INF changedPause | ${this.model} | ${isCleaning ? 'Paused possible' : 'Paused not possible, no cleaning'}`);
       }
       // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
+      this.services.fanSwitch.getCharacteristic(Characteristic.On).updateValue(isCleaning);
       this.services.pause.getCharacteristic(Characteristic.On).updateValue(isCleaning);
     }
   }

--- a/index.js
+++ b/index.js
@@ -615,7 +615,7 @@ class XiaomiRoborockVacuum {
     try {
       if (state) {
         await this.device.activateCleaning();
-      } else {
+      } else if (this.isCleaning) { // Only pause if still cleaning
         await this.device.pause();
       }
     } catch (err) {


### PR DESCRIPTION
Fixes #73 

iOS 13 is only showing the ON/OFF Pause switch in the new consolidated view. So the users can only pause/unpause the cleaning unless they go to Accessories and tap the right switch.

For this, I've created a new Start/Stop switch so the user knows what switch it's pressing at each time.

It's a bit ugly, but at least it works... 😅 