### PR TITLE
Stop on speed 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -560,7 +560,12 @@ class XiaomiRoborockVacuum {
 
     this.log.info(`ACT setSpeed | ${this.model} | FanSpeed set to ${miLevel} over miIO for "${name}".`);
 
-    await this.device.changeFanSpeed(miLevel);
+    if (miLevel === 0) {
+      this.log.debug(`DEB setSpeed | ${this.model} | FanSpeed is 0 => Calling setCleaning(false) instead of changing the fan speed`);
+      await this.setCleaning(false);
+    } else {
+      await this.device.changeFanSpeed(miLevel);
+    }
   }
 
   findWaterSpeedModeFromMiio(speed) {


### PR DESCRIPTION
Fixes #105 

When the speed is set to 0, it will call the go to the dock method instead of changing the speed to 0 (as changing the speed is actually setting a mode and some models apparently understand that mode as something else 😓).

@Tim2309 could you try the logic on this branch?
You can install from `git` instead of `npm`, by running these methods:
```
sudo su -
npm install -g afharo/homebridge-xiaomi-roborock-vacuum#stop-on-speed-0
```