### PR TITLE
Add subtype to the Pause Switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ class XiaomiRoborockVacuum {
       .on('get', (cb) => callbackify(() => this.getBatteryLow(), cb));
 
     if (this.config.pause) {
-      this.services.pause = new Service.Switch(`${this.config.name} Pause`);
+      this.services.pause = new Service.Switch(`${this.config.name} Pause`, 'Pause Switch');
       this.services.pause
         .getCharacteristic(Characteristic.On)
         .on('get', (cb) => callbackify(() => this.getPauseState(), cb))


### PR DESCRIPTION
Fixes #114 

When having multiple Services of the same type, we need to provide a subtype or home bridge will fail. Now, with the addition of the rooms' switches, we need to provide a subtype name to the Pause switch