### PR TITLE
Autoroom on roborock s5

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,18 @@ This plugin use the new [miio](https://github.com/aholstenson/miio) version 0.15
 | `waterBox` | false | when set to true, HomeKit shows an additional slider to control the amount of water released by the robot (only selected models like S5-Max). Currently in a beta state. |
 | `cleanword` | cleaning | used for autonaming the Roomselectors |
 | `rooms` | false | Array of ID / Name for a single Room. If set you have another switch for cleaning only this room |
-| `autoroom` | false | when set to true, Rooms will be generated from Robot. (only S6) |
+| `autoroom` | false | set to true to generate rooms from robot (only S6) or set to array of room name strings (see semi automatic below) |
 
 ## AutoRoom Generation
+
+### Fully automatic
 This feature seems to be working only on the S6 Model.
 We figured out this is why the Api call only delivers the mapping when the Rooms are named in the Xioami / Roborock App.
 
 So when you have an S6 but not named the Rooms in your App this function will not work! Thanks @domeOo
+
+### Semi automatic
+This feature seems to work with all models which offer room cleaning. To use it, in the config set `autoroom` to an array of room names. Then in the app, setup a timer at midnight (00:00 or 12:00am). Enable `Select a room to divide`. Then on the map select the rooms in the order as they appear in the homebridge config. The order is important as this is how the plugin maps the room names to IDs. Finally submit the timer and deactivate it. Then restart homebridge.
 
 ## Xiaomi Token
 To use this plugin, you have to read the "token" of the xiaomi vacuum robots. Here are some detailed instructions:

--- a/index.js
+++ b/index.js
@@ -600,27 +600,25 @@ class XiaomiRoborockVacuum {
 
     try {
       const map = await this.device.call('get_room_mapping');
-      this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
-      if(map.size() == 0) {
-        this.log.info(`INF No named rooms available. Try to get list of unnamed rooms`);
+      if(Object.keys(map).length == 0) {
+        this.log.info(`INF getRoomMap | ${this.model} | No named rooms available. Try to get list of unnamed rooms`);
         const timers = await this.device.call('get_timer');
         let leetTimer = timers.find(
           x => x[2][0].startswith("37 13"));
         if (leetTimer == undefined) {
-          this.log.error(`ERR Could not find a timer for autoroom`);
+          this.log.error(`ERR getRoomMap | ${this.model} | Could not find a timer for autoroom`);
+        } else {
+          let roomIds = leetTimer[2][1][1]['segments'];
+          if (roomIds == '0') {
+            this.log.error(`ERR getRoomMap | ${this.model} | Timer for autoroom does not have selected rooms`)
           } else {
-            let roomIds = leetTimer[2][1][1]['segments'];
-            if (roomIds == '0') {
-              this.log.error(`ERR Timer for autoroom does not have selected rooms`)
-            } else {
-              for (let id in roomIds)
-              {
-                this.createRoom(id, `Room ${id}`);
-              }
+            for (let id in roomIds) {
+              this.createRoom(id, `Room ${id}`);
             }
           }
         }
-      }
+      } else {
+      this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
       for(let val of map) {
         this.createRoom(val[0], val[1]);
       }

--- a/index.js
+++ b/index.js
@@ -601,10 +601,26 @@ class XiaomiRoborockVacuum {
     try {
       const map = await this.device.call('get_room_mapping');
       this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
-      if(map.size() == 0)
-        {
-            this.log.info(`Rooms are empty`);
+      if(map.size() == 0) {
+        this.log.info(`INF No named rooms available. Try to get list of unnamed rooms`);
+        const timers = await this.device.call('get_timer');
+        let leetTimer = timers.find(
+          x => x[2][0].startswith("37 13"));
+        if (leetTimer == undefined) {
+          this.log.error(`ERR Could not find a timer for autoroom`);
+          } else {
+            let roomIds = leetTimer[2][1][1]['segments'];
+            if (roomIds == '0') {
+              this.log.error(`ERR Timer for autoroom does not have selected rooms`)
+            } else {
+              for (let id in roomIds)
+              {
+                this.createRoom(id, `Room ${id}`);
+              }
+            }
+          }
         }
+      }
       for(let val of map) {
         this.createRoom(val[0], val[1]);
       }

--- a/index.js
+++ b/index.js
@@ -615,16 +615,18 @@ class XiaomiRoborockVacuum {
       }
 
       let roomIds = leetTimer[2][1][1]['segments'].split`,`.map(x=>+x);
-      this.log.info(`INF getRoomList | ${this.model} | Room IDs are ${roomIds}`);
+      this.log.debug(`DEB getRoomList | ${this.model} | Room IDs are ${roomIds}`);
 
       if (roomIds.length != this.config.autoroom.length) {
         this.log.error(`ERR getRoomList | ${this.model} | Number of rooms in config does not match number of rooms in the timer`);
         return;
       }
-
+      let roomMap = [];
       for (const [i, roomId] of roomIds.entries()) {
         this.createRoom(roomId, this.config.autoroom[i]);
+        roomMap.push({'id': roomId, 'name': this.config.autoroom[i]});
       }
+      this.log.info(`INF getRoomList | ${this.model} | Created "rooms": ${JSON.stringify(roomMap)}`);
     } catch (err) {
       this.log.error(`ERR getRoomList | Failed getting the Room List.`, err);
       throw err;

--- a/index.js
+++ b/index.js
@@ -604,23 +604,24 @@ class XiaomiRoborockVacuum {
         this.log.info(`INF getRoomMap | ${this.model} | No named rooms available. Try to get list of unnamed rooms`);
         const timers = await this.device.call('get_timer');
         let leetTimer = timers.find(
-          x => x[2][0].startswith("37 13"));
+          x => x[2][0].startsWith("37 13"));
         if (leetTimer == undefined) {
           this.log.error(`ERR getRoomMap | ${this.model} | Could not find a timer for autoroom`);
         } else {
-          let roomIds = leetTimer[2][1][1]['segments'];
-          if (roomIds == '0') {
+          let roomIds = leetTimer[2][1][1]['segments'].split`,`.map(x=>+x);
+          if (roomIds.length == 1 && roomIds[0] == 0) {
             this.log.error(`ERR getRoomMap | ${this.model} | Timer for autoroom does not have selected rooms`)
           } else {
-            for (let id in roomIds) {
+            for (let id of roomIds) {
               this.createRoom(id, `Room ${id}`);
             }
           }
         }
       } else {
-      this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
-      for(let val of map) {
-        this.createRoom(val[0], val[1]);
+        this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
+        for(let val of map) {
+          this.createRoom(val[0], val[1]);
+        }
       }
     } catch (err) {
       this.log.error(`ERR getRoomMap | Failed getting the Room Map.`, err);

--- a/index.js
+++ b/index.js
@@ -604,8 +604,11 @@ class XiaomiRoborockVacuum {
 
     try {
       const timers = await this.device.call('get_timer');
+
+      // Find specific timer containing the room order
+      // Timer needs to be scheduled for 00:00 and inactive
       let leetTimer = timers.find(
-        x => x[2][0].startsWith("37 13"));
+        x => x[2][0].startsWith("0 0") && x[1] == 'off');
       if (leetTimer == undefined) {
         this.log.error(`ERR getRoomList | ${this.model} | Could not find a timer for autoroom`);
         return;

--- a/index.js
+++ b/index.js
@@ -358,11 +358,11 @@ class XiaomiRoborockVacuum {
       this.log.info('STA getDevice | BatteryLevel: ' + this.device.property("batteryLevel"));
 
       if (this.config.autoroom) {
-	if (Array.isArray(this.config.autoroom)) {
-	  await this.getRoomList();
-	} else {
-          await this.getRoomMap();
-	}
+        if (Array.isArray(this.config.autoroom)) {
+           await this.getRoomList();
+        } else {
+           await this.getRoomMap();
+        }
       }
 
       try {
@@ -619,7 +619,7 @@ class XiaomiRoborockVacuum {
 
       if (roomIds.length != this.config.autoroom.length) {
         this.log.error(`ERR getRoomList | ${this.model} | Number of rooms in config does not match number of rooms in the timer`);
-	 return;
+        return;
       }
 
       for (const [i, roomId] of roomIds.entries()) {

--- a/index.js
+++ b/index.js
@@ -601,6 +601,10 @@ class XiaomiRoborockVacuum {
     try {
       const map = await this.device.call('get_room_mapping');
       this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
+      if(map.size() == 0)
+        {
+            this.log.info(`Rooms are empty`);
+        }
       for(let val of map) {
         this.createRoom(val[0], val[1]);
       }


### PR DESCRIPTION
This pull request adds an automatic retrieval of roomIDs via an inactive timer for room cleaning set up. It was suggested in issue #149. Instructions on how to set the config file and how to set the timer are in the README.md

The PR introduces a new member variable saving the room mapping. This is since the HomeKit services need to be created before the robot can be queried for room ids. This way it is possible to change the after service creation as soon as it is known.