### PR TITLE
Move system-sleep to optional dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,12 @@ const miio = require('miio-nicoh88');
 const util = require('util');
 const callbackify = require('./lib/callbackify');
 const safeCall = require('./lib/safeCall');
-const sleep = require('system-sleep');
+let sleep;
+try {
+  sleep = require('system-sleep');
+} catch (e) {
+  // noop
+}
 
 let homebrideAPI, Service, Characteristic;
 
@@ -898,10 +903,17 @@ class XiaomiRoborockVacuum {
   }
 
   getServices() {
-    if (this.config.delay)
-      sleep(5000);
+    if (this.config.delay) this.sleep(5000);
     this.log.debug(`DEB getServices | ${this.model}`);
     return Object.keys(this.services).map((key) => this.services[key]);
+  }
+
+  sleep(time) {
+    if (sleep) {
+      sleep(time);
+    } else {
+      this.log.warn(`Can't use the delay option because sleep failed to install`);
+    }
   }
 
   // CONSUMABLE / CARE

--- a/index.js
+++ b/index.js
@@ -912,7 +912,8 @@ class XiaomiRoborockVacuum {
     if (sleep) {
       sleep(time);
     } else {
-      this.log.warn(`Can't use the delay option because sleep failed to install`);
+      this.log.warn(`Can't use the delay option because the module "system-sleep" failed to install.\n
+      Make sure this optional dependency is properly installed if you want to use the "delay" option.`);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
   },
   "dependencies": {
     "miio-nicoh88": ">=0.1.0",
-    "semver": "^7.1.2",
+    "semver": "^7.1.2"
+  },
+  "optionalDependencies": {
     "system-sleep": "^1.3.6"
   }
 }


### PR DESCRIPTION
Fix #151 

@c-o-m-m-a-n-d-e-r it looks like that compilation error in #151 is due to the installation of `system-sleep` in that environment. 

Does it make sense if we move it to optional dependencies?