### PR TITLE
0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+#### 0.7.7
+- [Models] Add "Mop" mode for model S6 (#144)
+- [Models] Add "Custom" mode for model S5-Max (#110)
+- [Fix] Move `system-sleep` to optional dependencies to fix installation errors that fail to compile it (#151)
+
 #### 0.7.6
 - [Feature] Semiautomatic determination of room ids ([read the README for usage](./README.md#semi-automatic))
 - [Fix] Log errors when not an error from the protocol

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-xiaomi-roborock-vacuum",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Xiaomi Vacuum Cleaner - 1st (Mi Robot), 2nd (Roborock S50 + S55), 3rd Generation (Roborock S6) and S5 Max - plugin for Homebridge.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
- [Models] Add "Mop" mode for model S6 (#144)
- [Models] Add "Custom" mode for model S5-Max (#110)
- [Fix] Move `system-sleep` to optional dependencies to fix installation errors that fail to compile it (#151)