### PR TITLE
Proportional steps in speed + RotationSpeed.minStep

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,6 +547,12 @@ class XiaomiRoborockVacuum {
         }
       });
 
+      // Now that we know the model, amend the steps in the Rotation speed (for better usability)
+      const minStep = 100 / (this.findSpeedModes().length - 1);
+      this.services.fan
+        .getCharacteristic(Characteristic.RotationSpeed)
+        .setProps({ minStep });
+
       await this.getState();
       // Refresh the state every 30s so miio maintains a fresh connection (or recovers connection if lost until we fix https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/81)
       clearInterval(this.getStateInterval);

--- a/models/speedmodes.js
+++ b/models/speedmodes.js
@@ -1,74 +1,104 @@
 "use strict";
 
-module.exports = {
+const SPEEDMODES = {
   gen1: [
-    // 0%       = Off / Aus
-    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
-    // 1-38%   = "Quiet / Leise"
-    { homekitTopLevel: 38, miLevel: 38, name: "Quiet" },
-    // 39-60%  = "Balanced / Standard"
-    { homekitTopLevel: 60, miLevel: 60, name: "Balanced" },
-    // 61-77%  = "Turbo / Stark"
-    { homekitTopLevel: 77, miLevel: 77, name: "Turbo" },
-    // 78-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 90, name: "Max" },
+    // 0%      = Off / Aus
+    { miLevel: 0, name: "Off" },
+    // 0-25%  = "Quiet / Leise"
+    { miLevel: 38, name: "Quiet" },
+    // 26-50%  = "Balanced / Standard"
+    { miLevel: 60, name: "Balanced" },
+    // 51-75%  = "Turbo / Stark"
+    { miLevel: 77, name: "Turbo" },
+    // 76-100% = "Full Speed / Max Speed / Max"
+    { miLevel: 90, name: "Max" },
   ],
   gen2: [
     // 0%      = Off / Aus
-    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
-    // 1-15%   = "Mop / Mopping / Nur wischen"
-    { homekitTopLevel: 15, miLevel: 105, name: "Mop" },
-    // 16-38%  = "Quiet / Leise"
-    { homekitTopLevel: 38, miLevel: 38, name: "Quiet" },
-    // 39-60%  = "Balanced / Standard"
-    { homekitTopLevel: 60, miLevel: 60, name: "Balanced" },
-    // 61-75%  = "Turbo / Stark"
-    { homekitTopLevel: 75, miLevel: 75, name: "Turbo" },
-    // 76-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 100, name: "Max" },
+    { miLevel: 0, name: "Off" },
+    // 1-20%   = "Mop / Mopping / Nur wischen"
+    { miLevel: 105, name: "Mop" },
+    // 21-40%  = "Quiet / Leise"
+    { miLevel: 38, name: "Quiet" },
+    // 41-60%  = "Balanced / Standard"
+    { miLevel: 60, name: "Balanced" },
+    // 61-80%  = "Turbo / Stark"
+    { miLevel: 75, name: "Turbo" },
+    // 81-100% = "Full Speed / Max Speed / Max"
+    { miLevel: 100, name: "Max" },
   ],
   gen3: [
     // 0%      = Off / Aus
-    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
-    // 1-38%   = "Quiet / Leise"
-    { homekitTopLevel: 38, miLevel: 101, name: "Quiet" },
-    // 39-60%  = "Balanced / Standard"
-    { homekitTopLevel: 60, miLevel: 102, name: "Balanced" },
-    // 61-77%  = "Turbo / Stark"
-    { homekitTopLevel: 77, miLevel: 103, name: "Turbo" },
-    // 78-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 104, name: "Max" },
+    { miLevel: 0, name: "Off" },
+    // 1-25%   = "Quiet / Leise"
+    { miLevel: 101, name: "Quiet" },
+    // 26-50%  = "Balanced / Standard"
+    { miLevel: 102, name: "Balanced" },
+    // 51-75%  = "Turbo / Stark"
+    { miLevel: 103, name: "Turbo" },
+    // 76-100% = "Full Speed / Max Speed / Max"
+    { miLevel: 104, name: "Max" },
   ],
   // S5-Max (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
   gen4: [
     // 0%      = Off / Aus
-    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
-    // 1-15%   = "Soft"
-    { homekitTopLevel: 15, miLevel: 105, name: "Soft" },
-    // 16-38%   = "Quiet / Leise"
-    { homekitTopLevel: 38, miLevel: 101, name: "Quiet" },
-    // 39-60%  = "Balanced / Standard"
-    { homekitTopLevel: 60, miLevel: 102, name: "Balanced" },
-    // 61-77%  = "Turbo / Stark"
-    { homekitTopLevel: 77, miLevel: 103, name: "Turbo" },
-    // 78-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 104, name: "Max" },
+    { miLevel: 0, name: "Off" },
+    // 1-20%   = "Soft"
+    { miLevel: 105, name: "Soft" },
+    // 21-40%   = "Quiet / Leise"
+    { miLevel: 101, name: "Quiet" },
+    // 41-60%  = "Balanced / Standard"
+    { miLevel: 102, name: "Balanced" },
+    // 61-80%  = "Turbo / Stark"
+    { miLevel: 103, name: "Turbo" },
+    // 81-100% = "Full Speed / Max Speed / Max"
+    { miLevel: 104, name: "Max" },
   ],
   // S5-Max + Custom (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/110)
   "gen4+custom": [
     // 0%      = Off / Aus
-    { homekitTopLevel: 0, miLevel: 0, name: "Off" },
-    // 1-15%   = "Soft"
-    { homekitTopLevel: 15, miLevel: 105, name: "Soft" },
-    // 16-38%   = "Quiet / Leise"
-    { homekitTopLevel: 38, miLevel: 101, name: "Quiet" },
-    // 39-60%  = "Balanced / Standard"
-    { homekitTopLevel: 60, miLevel: 102, name: "Balanced" },
-    // 61-77%  = "Turbo / Stark"
-    { homekitTopLevel: 77, miLevel: 103, name: "Turbo" },
-    // 78-90% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 90, miLevel: 104, name: "Max" },
-    // 91-100% = "Custom"
-    { homekitTopLevel: 100, miLevel: 106, name: "Custom" },
+    { miLevel: 0, name: "Off" },
+    // 1-16%   = "Soft"
+    { miLevel: 105, name: "Soft" },
+    // 17-32%   = "Quiet / Leise"
+    { miLevel: 101, name: "Quiet" },
+    // 33-48%  = "Balanced / Standard"
+    { miLevel: 102, name: "Balanced" },
+    // 49-64%  = "Turbo / Stark"
+    { miLevel: 103, name: "Turbo" },
+    // 65-80% = "Full Speed / Max Speed / Max"
+    { miLevel: 104, name: "Max" },
+    // 81-100% = "Custom"
+    { miLevel: 106, name: "Custom" },
   ],
 };
+
+/**
+ * Loops through all the speedmodes and assigns the `homekitTopLevel` with proportional steps.
+ *
+ * i.e.:
+ * - If 5 possible states => 0%, 25%, 50%, 75% and 100%
+ * - If 6 possible states => 0%, 20%, 40%, 60%, 80% and 100%
+ * - If 7 possible states => 0%, 16%, 32%, 48%, 64%, 80% and 96%
+ *
+ * @returns object The SPEEDMODES + the addition of the `homekitTopLevel` property to each entry
+ */
+function autoAssignHomekitTopLevel() {
+  const generations = Object.keys(SPEEDMODES);
+  return generations.reduce((acc, gen) => {
+    const speedmodes = SPEEDMODES[gen].map((mode, index, modes) => {
+      const step = Math.floor(100 / (modes.length - 1));
+      return Object.assign(
+        {},
+        {
+          // if it's the last element, max it out to 100%
+          homekitTopLevel: index === modes.length - 1 ? 100 : index * step,
+        },
+        mode // set later should we want to overwrite this logic in the SPEEDMODES definition
+      );
+    });
+    return Object.assign({}, acc, { [gen]: speedmodes });
+  }, {});
+}
+
+module.exports = autoAssignHomekitTopLevel();


### PR DESCRIPTION
Fixes #131 

This PR implements @maisun's suggestion to evenly spaced the modes in the `RotationSpeed` so we can set the Homekit's property `minStep`.

This should make it easier to control via the app, since it won't jump 1-by-1% but it will directly jump to the allowed speeds.

⚠️ It may be considered a breaking change since it may affect some automation for folks out there. Remember to mention it in the changelog if this PR is accepted.