### PR TITLE
Use Prettier for code styling enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,131 +1,164 @@
 # Changes
 
-#### 0.7.7
+## 0.7.7
+
 - [Models] Add "Mop" mode for model S6 (#144)
 - [Models] Add "Custom" mode for model S5-Max (#110)
 - [Fix] Move `system-sleep` to optional dependencies to fix installation errors that fail to compile it (#151)
 
-#### 0.7.6
+## 0.7.6
+
 - [Feature] Semiautomatic determination of room ids ([read the README for usage](./README.md#semi-automatic))
 - [Fix] Log errors when not an error from the protocol
 
-#### 0.7.5
+## 0.7.5
+
 - Bugfix: Move "miio" lib git-package to npm-package "miio-nicoh88"
 
-#### 0.7.3
+## 0.7.3
+
 - Feature: Add support for Roborock T4 with gen3 speeds
 - Feature: AutoRoom Generation (only S6)
 - Feature: Add support for Mi Vacuum Robot 1S
 - Feature: Startdelay for testing
 
-#### 0.7.2
+## 0.7.2
+
 - Bugfix: Stop cleaning, go to dock
 
-#### 0.7.1
+## 0.7.1
+
 - Bugfix: config.schema.json update for homebridge-config-ui-x
 - Bugfix: config cleanword default "cleaning" if not sets in config.json
 - Bugfix: Add subtype to the pause switch
 
-#### 0.7.0
+## 0.7.0
+
 - Feature: Room cleaning with separately switch for each room
 
-#### 0.6.8
+## 0.6.8
+
 - Bugfix: Going to dock on speed 0, not stop
 
-#### 0.6.7
+## 0.6.7
+
 - Bugfix: Readme fix
 
-#### 0.6.6
+## 0.6.6
+
 - Feature: Support the new WaterBox property (S5 Max)
 - Improve: Reduce changed logs by only logging when the value is actually new
 - Improve: Vacuum error handling
 - Improve: Fanspeed / Fanmode handling
-- Improve: miio library accept all "WORD.vacuum.*"
+- Improve: miio library accept all "WORD.vacuum.\*"
 - Bugfix: Fix the unhandled promises
 
-#### 0.6.5
+## 0.6.5
+
 - Feature: Add support for Roborock S5 Max
 - Improve: Refresh the state every 30s to ensure miio is still properly connected
 - Bugfix: Battery level
 - Bugfix: UnhandledPromiseRejectionWarning on startup when it fails to connect
 
-#### 0.6.4
+## 0.6.4
+
 - Feature: Add support for Roborock Xiaowa E20
 
-#### 0.6.3
+## 0.6.3
+
 - Improve: roborock.vacuum.t6 fanSpeed not supported issue [PR](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/pull/70)
 
-#### 0.6.2
+## 0.6.2
+
 - Feature: Add support for Mi Robot 1S
 - Improve: Controlled Connection Retries [PR](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/pull/66)
 
-#### 0.6.1
+## 0.6.1
+
 - Feature: Add support for Roborock T6
 
-#### 0.6.0
+## 0.6.0
+
 - Improve: Support for Roborock S6
 - Improve: More generic logic on the different model's speed modes definition
 
-#### 0.5.1
+## 0.5.1
+
 - Feature: Add support for Roborock S6
 
-#### 0.5.0
+## 0.5.0
+
 - Refactoring by @afharo
   - re-connection mechanism
   - javascript promises (async/await)
 
-#### 0.4.2
+## 0.4.2
+
 - Feature: Add support for homebridge-config-ui-x - thx @pisikaki
 
-#### 0.4.1
+## 0.4.1
+
 - Update engine versions from homebridge and node
 
-#### 0.4.0
+## 0.4.0
+
 - Feature: Mopping is now supported. [#31](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/31)
 - Feature: Slightly different Speedmodes between Gen1 and Gen2 considered.
 - Bugfix: Initializing status values to variables at startup, there were problems when the robot was not docked when starting homebridge. [#15](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/15) & [#30](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/30)
 - Bugfix: `pause` functionality improved. [#15](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/15) & [#30](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/30)
 - Bugfix: Logging improved.
 
-#### 0.3.2
+## 0.3.2
+
 - Bugfix: "Unknown error" with meaningful error message.
 
-#### 0.3.1
+## 0.3.1
+
 - README customized (`root` with `sudo su -`).
 
-#### 0.3.0
+## 0.3.0
+
 - Feature: Additional characteristics (4) for care indicator of sensors, side brush, main brush and filter added (Eve App).
 
-#### 0.2.2
+## 0.2.2
+
 - Bugfix: Own Fork from "miio" with fixed for [#5](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/5), [#6](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/6) and [#7](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/7).
 
-#### 0.2.1
+## 0.2.1
+
 - Bugfix: Fanspeed levels over HomeKit improved.
 
-#### 0.2.0
+## 0.2.0
+
 - Rewrite plugin, changed logic.
 - Bugfix: Connection establishment improved.
 - Bugfix: `UnhandledPromiseRejectionWarning`
 
-#### 0.1.5
+## 0.1.5
+
 - Feature: ERRORs from miio-API added.
 
-#### 0.1.4
+## 0.1.4
+
 - Bugfix: If `pause` / `dock` in `config.json` enabled.
 - Bugfix: `cannot read property getCharacteristic of undefined`.
 
-#### 0.1.3
+## 0.1.3
+
 - Feature: Logging added.
 - Bugfix: `UnhandledPromiseRejectionWarning`.
 - README customized.
 
-#### 0.1.2
+## 0.1.2
+
 - Feature: Deviceinfos (model, serial and firmware version) shows at startup.
 - Bugfix: `UnhandledPromiseRejectionWarning`.
 - README customized.
 
-#### 0.1.1
+## 0.1.1
+
 - README typo.
 
-#### 0.1.0
+## 0.1.0
+
 - First version.

--- a/README.md
+++ b/README.md
@@ -7,26 +7,27 @@
 # homebridge-xiaomi-roborock-vacuum
 
 ## Homebridge plugin for Xiaomi / Roborock Vacuum Cleaner's
+
 With this [homebridge](https://github.com/nfarina/homebridge) plugin can you control the xiaomi vacuum robots as fan in your Apple Home App (HomeKit).
 
 This plugin use the new [miio](https://github.com/aholstenson/miio) version 0.15.6 or newer, not like the old ones 0.14.1. Timeouts and API errors are a thing of the past!
 
 <img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/rockrobo.vacuum.v1.jpg" style="border:1px solid lightgray" alt="Xiaomi Mi Robot 1st Generation (Roborock Vacuum V1)" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s5.jpg" style="border:1px solid lightgray" alt="Roborock S50 2nd Generation" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s55.jpg" style="border:1px solid lightgray" alt="Roborock S55 2nd Generation Black" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s6.jpg" style="border:1px solid lightgray" alt="Roborock S6/T6 3nd Generation" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.c10.jpg" style="border:1px solid lightgray" alt="Roborock Xiaowa Lite C10" width="300">&nbsp;&nbsp;&nbsp;<img src="https://raw.githubusercontent.com/nicoh88/homebridge-xiaomi-roborock-vacuum/master/roborock.vacuum.s5.max.jpg" style="border:1px solid lightgray" alt="Roborock S5 Max" width="300">
 
-
 ## Features
-* **Fan** as On-/Off-Switch. When switching off, directly back to the charging station.
-   * [Fanspeed levels](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/models/speedmodes.js) adjustable via 3D Touch / Force Touch.
-* Battery status and condition in the device details. Low battery alert.
-* Pause switch (optional).
-* Occupancy sensor (similar to motion sensor) for dock status (optional).
-* Seconds Fan for water box modes (optional).
+
+- **Fan** as On-/Off-Switch. When switching off, directly back to the charging station.
+  - [Fanspeed levels](https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/models/speedmodes.js) adjustable via 3D Touch / Force Touch.
+- Battery status and condition in the device details. Low battery alert.
+- Pause switch (optional).
+- Occupancy sensor (similar to motion sensor) for dock status (optional).
+- Seconds Fan for water box modes (optional).
 
 <img src="https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/screenshot1.jpg?raw=true" alt="Screenshot Apple HomeKit with homebridge-xiaomi-roborock-vacuum" width="350">
 <img src="https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/blob/master/screenshot2.jpg?raw=true" alt="Screenshot Elgato Eve App with homebridge-xiaomi-roborock-vacuum" width="350">
 
-
 ## Instructions
+
 1. Install git packages first with `sudo apt install git`.
 2. Install the plugin as `root` (`sudo su -`) with `npm install -g homebridge-xiaomi-roborock-vacuum@latest --unsafe-perm`.
 3. Customize you homebridge configuration `config.json`.
@@ -98,31 +99,35 @@ This plugin use the new [miio](https://github.com/aholstenson/miio) version 0.15
 ],
 ```
 
-
 ## Optional parameters
-| Name of parameter | Default value | Notes |
-|---|---|---|
-| `pause` | false | when set to true, HomeKit shows an additional switch for "pause" - switch is on, when pause is possible |
-| `dock` | false |  when set to true, HomeKit shows an occupancy sensor, if robot is in the charging dock |
-| `waterBox` | false | when set to true, HomeKit shows an additional slider to control the amount of water released by the robot (only selected models like S5-Max). Currently in a beta state. |
-| `cleanword` | cleaning | used for autonaming the Roomselectors |
-| `rooms` | false | Array of ID / Name for a single Room. If set you have another switch for cleaning only this room |
-| `zones` | false | Array of name / zone coordinates for a single zone group. A zone group may contain multiple zone squares, each with its own value for number of cleanings.  Coordinates are laid out as bottom-left-x, bottom-left-y, top-right-x, top-right-y, number-of-cleanings.  A separate tile in Home will be created for each zone group.  Figuring out coordinates will take some trial and error.  Each zone should be surrounded by brackets: [], with the entire value also surrounded by brackets. 
-| `autoroom` | false | set to true to generate rooms from robot (only S6) or set to array of room name strings (see semi automatic below) |
+
+| Name of parameter | Default value | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pause`           | false         | when set to true, HomeKit shows an additional switch for "pause" - switch is on, when pause is possible                                                                                                                                                                                                                                                                                                                                                                                      |
+| `dock`            | false         | when set to true, HomeKit shows an occupancy sensor, if robot is in the charging dock                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `waterBox`        | false         | when set to true, HomeKit shows an additional slider to control the amount of water released by the robot (only selected models like S5-Max). Currently in a beta state.                                                                                                                                                                                                                                                                                                                     |
+| `cleanword`       | cleaning      | used for autonaming the Roomselectors                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `rooms`           | false         | Array of ID / Name for a single Room. If set you have another switch for cleaning only this room                                                                                                                                                                                                                                                                                                                                                                                             |
+| `zones`           | false         | Array of name / zone coordinates for a single zone group. A zone group may contain multiple zone squares, each with its own value for number of cleanings. Coordinates are laid out as bottom-left-x, bottom-left-y, top-right-x, top-right-y, number-of-cleanings. A separate tile in Home will be created for each zone group. Figuring out coordinates will take some trial and error. Each zone should be surrounded by brackets: [], with the entire value also surrounded by brackets. |
+| `autoroom`        | false         | set to true to generate rooms from robot (only S6) or set to array of room name strings (see semi automatic below)                                                                                                                                                                                                                                                                                                                                                                           |
 
 ## AutoRoom Generation
 
 ### Fully automatic
+
 This feature seems to be working only on the S6 Model.
 We figured out this is why the Api call only delivers the mapping when the Rooms are named in the Xioami / Roborock App.
 
 So when you have an S6 but not named the Rooms in your App this function will not work! Thanks @domeOo
 
 ### Semi automatic
+
 This feature seems to work with all models which offer room cleaning. To use it, in the config set `autoroom` to an array of room names. Then in the app, setup a timer at midnight (00:00 or 12:00am). Enable `Select a room to divide`. Then on the map select the rooms in the order as they appear in the homebridge config. The order is important as this is how the plugin maps the room names to IDs. Finally submit the timer and deactivate it. Then restart homebridge.
 
 ## Xiaomi Token
+
 To use this plugin, you have to read the "token" of the xiaomi vacuum robots. Here are some detailed instructions:
+
 - :us::gb: - [python-miio - Getting started](https://python-miio.readthedocs.io/en/latest/discovery.html)
 - :de: - [Apple HomeKit Forum - HomeKit.Community](https://forum.smartapfel.de/forum/thread/370-xiaomi-token-auslesen/)
 - :de: - [Homematic-Guru.de](https://homematic-guru.de/xiaomi-vacuum-staubsauger-roboter-mit-homematic-steuern)

--- a/config.schema.json
+++ b/config.schema.json
@@ -102,10 +102,7 @@
     {
       "type": "flex",
       "flex-flow": "row wrap",
-      "items": [
-        "ip",
-        "token"
-      ]
+      "items": ["ip", "token"]
     },
     "waterBox",
     "pause",
@@ -116,7 +113,7 @@
     {
       "type": "fieldset",
       "title": "Rooms",
-      "description": "Room Mapping", 
+      "description": "Room Mapping",
       "expandable": true,
       "expanded": false,
       "items": [
@@ -151,7 +148,7 @@
     {
       "type": "fieldset",
       "title": "Zones",
-      "description": "Zone cleaning", 
+      "description": "Zone cleaning",
       "expandable": true,
       "expanded": false,
       "items": [

--- a/index.js
+++ b/index.js
@@ -1,23 +1,23 @@
-'use strict';
+"use strict";
 
-const semver = require('semver');
-const miio = require('miio-nicoh88');
-const util = require('util');
-const callbackify = require('./lib/callbackify');
-const safeCall = require('./lib/safeCall');
+const semver = require("semver");
+const miio = require("miio-nicoh88");
+const util = require("util");
+const callbackify = require("./lib/callbackify");
+const safeCall = require("./lib/safeCall");
 let sleep;
 try {
-  sleep = require('system-sleep');
+  sleep = require("system-sleep");
 } catch (e) {
   // noop
 }
 
 let homebrideAPI, Service, Characteristic;
 
-const PLUGIN_NAME = 'homebridge-xiaomi-roborock-vacuum';
-const ACCESSORY_NAME = 'XiaomiRoborockVacuum';
+const PLUGIN_NAME = "homebridge-xiaomi-roborock-vacuum";
+const ACCESSORY_NAME = "XiaomiRoborockVacuum";
 
-const MODELS = require('./models');
+const MODELS = require("./models");
 const GET_STATE_INTERVAL_MS = 30000; // 30s
 
 module.exports = function (homebridge) {
@@ -27,54 +27,77 @@ module.exports = function (homebridge) {
   homebrideAPI = homebridge;
   // UUIDGen = homebridge.hap.uuid;
 
-  homebridge.registerAccessory(PLUGIN_NAME, ACCESSORY_NAME, XiaomiRoborockVacuum);
-}
+  homebridge.registerAccessory(
+    PLUGIN_NAME,
+    ACCESSORY_NAME,
+    XiaomiRoborockVacuum
+  );
+};
 
 class XiaomiRoborockVacuum {
   // From https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L128
   static get cleaningStatuses() {
-    return [
-      'cleaning',
-      'spot-cleaning',
-      'zone-cleaning',
-      'room-cleaning'
-    ];
+    return ["cleaning", "spot-cleaning", "zone-cleaning", "room-cleaning"];
   }
 
   static get errors() {
     return {
-      id1: { description: 'Try turning the orange laserhead to make sure it isnt blocked.' },
-      id2: { description: 'Clean and tap the bumpers lightly.' },
-      id3: { description: 'Try moving the vacuum to a different place.' },
-      id4: { description: 'Wipe the cliff sensor clean and move the vacuum to a different place.' },
-      id5: { description: 'Remove and clean the main brush.' },
-      id6: { description: 'Remove and clean the sidebrushes.' },
-      id7: { description: 'Make sure the wheels arent blocked. Move the vacuum to a different place and try again.' },
-      id8: { description: 'Make sure there are no obstacles around the vacuum.' },
-      id9: { description: 'Install the dustbin and the filter.' },
-      id10: { description: 'Make sure the filter has been tried or clean the filter.' },
-      id11: { description: 'Strong magnetic field detected. Move the device away from the virtual wall and try again' },
-      id12: { description: 'Battery is low, charge your vacuum.' },
-      id13: { description: 'Couldnt charge properly. Make sure the charging surfaces are clean.' },
-      id14: { description: 'Battery malfunctioned.' },
-      id15: { description: 'Wipe the wall sensor clean.' },
-      id16: { description: 'Use the vacuum on a flat horizontal surface.' },
-      id17: { description: 'Sidebrushes malfunctioned. Reboot the system.' },
-      id18: { description: 'Fan malfunctioned. Reboot the system.' },
-      id19: { description: 'The docking station is not connected to power.' },
-      id20: { description: 'unkown' },
-      id21: { description: 'Please make sure that the top cover of the laser distance sensor is not pinned.' },
-      id22: { description: 'Please wipe the dock sensor.' },
-      id23: { description: 'Make sure the signal emission area of dock is clean.' }
+      id1: {
+        description:
+          "Try turning the orange laserhead to make sure it isnt blocked.",
+      },
+      id2: { description: "Clean and tap the bumpers lightly." },
+      id3: { description: "Try moving the vacuum to a different place." },
+      id4: {
+        description:
+          "Wipe the cliff sensor clean and move the vacuum to a different place.",
+      },
+      id5: { description: "Remove and clean the main brush." },
+      id6: { description: "Remove and clean the sidebrushes." },
+      id7: {
+        description:
+          "Make sure the wheels arent blocked. Move the vacuum to a different place and try again.",
+      },
+      id8: {
+        description: "Make sure there are no obstacles around the vacuum.",
+      },
+      id9: { description: "Install the dustbin and the filter." },
+      id10: {
+        description: "Make sure the filter has been tried or clean the filter.",
+      },
+      id11: {
+        description:
+          "Strong magnetic field detected. Move the device away from the virtual wall and try again",
+      },
+      id12: { description: "Battery is low, charge your vacuum." },
+      id13: {
+        description:
+          "Couldnt charge properly. Make sure the charging surfaces are clean.",
+      },
+      id14: { description: "Battery malfunctioned." },
+      id15: { description: "Wipe the wall sensor clean." },
+      id16: { description: "Use the vacuum on a flat horizontal surface." },
+      id17: { description: "Sidebrushes malfunctioned. Reboot the system." },
+      id18: { description: "Fan malfunctioned. Reboot the system." },
+      id19: { description: "The docking station is not connected to power." },
+      id20: { description: "unkown" },
+      id21: {
+        description:
+          "Please make sure that the top cover of the laser distance sensor is not pinned.",
+      },
+      id22: { description: "Please wipe the dock sensor." },
+      id23: {
+        description: "Make sure the signal emission area of dock is clean.",
+      },
     };
   }
 
   constructor(log, config) {
     this.log = log;
     this.config = config;
-    this.config.name = config.name || 'Roborock vacuum cleaner';
-    this.config.cleanword = config.cleanword || 'cleaning';
-    this.config.delay = config.delay || false;
+    this.config.name = config.name || "Roborock vacuum cleaner";
+    this.config.cleanword = config.cleanword || "cleaning";
+    this.config.delay = config.delay || false;
     this.services = {};
 
     // Used to store the latest state to reduce logging
@@ -86,11 +109,11 @@ class XiaomiRoborockVacuum {
     this.getStateInterval = setInterval(() => void 0, GET_STATE_INTERVAL_MS); // Noop timeout only to initialise the property
 
     if (!this.config.ip) {
-      throw new Error('You must provide an ip address of the vacuum cleaner.');
+      throw new Error("You must provide an ip address of the vacuum cleaner.");
     }
 
     if (!this.config.token) {
-      throw new Error('You must provide a token of the vacuum cleaner.');
+      throw new Error("You must provide a token of the vacuum cleaner.");
     }
 
     // HOMEKIT SERVICES
@@ -105,83 +128,101 @@ class XiaomiRoborockVacuum {
   initialiseServices() {
     this.services.info = new Service.AccessoryInformation();
     this.services.info
-      .setCharacteristic(Characteristic.Manufacturer, 'Xiaomi')
-      .setCharacteristic(Characteristic.Model, 'Roborock');
+      .setCharacteristic(Characteristic.Manufacturer, "Xiaomi")
+      .setCharacteristic(Characteristic.Model, "Roborock");
     this.services.info
       .getCharacteristic(Characteristic.FirmwareRevision)
-      .on('get', (cb) => callbackify(() => this.getFirmware(), cb));
+      .on("get", (cb) => callbackify(() => this.getFirmware(), cb));
     this.services.info
       .getCharacteristic(Characteristic.Model)
-      .on('get', (cb) => callbackify(() => this.device.miioModel, cb));
+      .on("get", (cb) => callbackify(() => this.device.miioModel, cb));
     this.services.info
       .getCharacteristic(Characteristic.SerialNumber)
-      .on('get', (cb) => callbackify(() => this.getSerialNumber(), cb));
+      .on("get", (cb) => callbackify(() => this.getSerialNumber(), cb));
 
-    this.services.fan = new Service.Fan(this.config.name, 'Speed');
+    this.services.fan = new Service.Fan(this.config.name, "Speed");
     this.services.fan
       .getCharacteristic(Characteristic.On)
-      .on('get', (cb) => callbackify(() => this.getCleaning(), cb))
-      .on('set', (newState, cb) => callbackify(() => this.setCleaning(newState), cb))
-      .on('change', (oldState, newState) => {
+      .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
+      .on("set", (newState, cb) =>
+        callbackify(() => this.setCleaning(newState), cb)
+      )
+      .on("change", (oldState, newState) => {
         this.changedPause(newState);
       });
     this.services.fan
       .getCharacteristic(Characteristic.RotationSpeed)
-      .on('get', (cb) => callbackify(() => this.getSpeed(), cb))
-      .on('set', (newState, cb) => callbackify(() => this.setSpeed(newState), cb));
+      .on("get", (cb) => callbackify(() => this.getSpeed(), cb))
+      .on("set", (newState, cb) =>
+        callbackify(() => this.setSpeed(newState), cb)
+      );
 
     if (this.config.waterBox) {
-      this.services.waterBox = new Service.Fan(`${this.config.name} Water Box`, 'Water Box');
+      this.services.waterBox = new Service.Fan(
+        `${this.config.name} Water Box`,
+        "Water Box"
+      );
       // TODO: Do we need to manage the Characteristic.On?
       this.services.waterBox
         .getCharacteristic(Characteristic.RotationSpeed)
-        .on('get', (cb) => callbackify(() => this.getWaterSpeed(), cb))
-        .on('set', (newState, cb) => callbackify(() => this.setWaterSpeed(newState), cb));
+        .on("get", (cb) => callbackify(() => this.getWaterSpeed(), cb))
+        .on("set", (newState, cb) =>
+          callbackify(() => this.setWaterSpeed(newState), cb)
+        );
     }
 
-    this.services.battery = new Service.BatteryService(`${this.config.name} Battery`);
+    this.services.battery = new Service.BatteryService(
+      `${this.config.name} Battery`
+    );
     this.services.battery
       .getCharacteristic(Characteristic.BatteryLevel)
-      .on('get', (cb) => callbackify(() => this.getBattery(), cb));
+      .on("get", (cb) => callbackify(() => this.getBattery(), cb));
     this.services.battery
       .getCharacteristic(Characteristic.ChargingState)
-      .on('get', (cb) => callbackify(() => this.getCharging(), cb));
+      .on("get", (cb) => callbackify(() => this.getCharging(), cb));
     this.services.battery
       .getCharacteristic(Characteristic.StatusLowBattery)
-      .on('get', (cb) => callbackify(() => this.getBatteryLow(), cb));
+      .on("get", (cb) => callbackify(() => this.getBatteryLow(), cb));
 
     if (this.config.pause) {
-      this.services.pause = new Service.Switch(`${this.config.name} Pause`, 'Pause Switch');
+      this.services.pause = new Service.Switch(
+        `${this.config.name} Pause`,
+        "Pause Switch"
+      );
       this.services.pause
         .getCharacteristic(Characteristic.On)
-        .on('get', (cb) => callbackify(() => this.getPauseState(), cb))
-        .on('set', (newState, cb) => callbackify(() => this.setPauseState(newState), cb));
+        .on("get", (cb) => callbackify(() => this.getPauseState(), cb))
+        .on("set", (newState, cb) =>
+          callbackify(() => this.setPauseState(newState), cb)
+        );
       // TODO: Add 'change' status?
     }
 
     if (this.config.dock) {
-      this.services.dock = new Service.OccupancySensor(`${this.config.name} Dock`);
+      this.services.dock = new Service.OccupancySensor(
+        `${this.config.name} Dock`
+      );
       this.services.dock
         .getCharacteristic(Characteristic.OccupancyDetected)
-        .on('get', (cb) => callbackify(() => this.getDocked(), cb));
+        .on("get", (cb) => callbackify(() => this.getDocked(), cb));
     }
 
     if (this.config.rooms && !this.config.autoroom) {
-      for(var i in this.config.rooms) {
+      for (var i in this.config.rooms) {
         this.createRoom(this.config.rooms[i].id, this.config.rooms[i].name);
       }
     }
 
     // Declare services for rooms in advance, so HomeKit can create the switches
     if (this.config.autoroom && Array.isArray(this.config.autoroom)) {
-      for(const i in this.config.autoroom) {
+      for (const i in this.config.autoroom) {
         // Index will be overwritten, when robot is available
         this.createRoom(i, this.config.autoroom[i]);
       }
     }
 
     if (this.config.zones) {
-      for(var i in this.config.zones) {
+      for (var i in this.config.zones) {
         this.createZone(this.config.zones[i].name, this.config.zones[i].zone);
       }
     }
@@ -192,81 +233,106 @@ class XiaomiRoborockVacuum {
 
   initialiseCareServices() {
     Characteristic.CareSensors = function () {
-      Characteristic.call(this, 'Care indicator sensors', '00000101-0000-0000-0000-000000000000');
+      Characteristic.call(
+        this,
+        "Care indicator sensors",
+        "00000101-0000-0000-0000-000000000000"
+      );
       this.setProps({
         format: Characteristic.Formats.FLOAT,
-        unit: '%',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+        unit: "%",
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
       });
       this.value = this.getDefaultValue();
     };
     util.inherits(Characteristic.CareSensors, Characteristic);
-    Characteristic.CareSensors.UUID = '00000101-0000-0000-0000-000000000000';
+    Characteristic.CareSensors.UUID = "00000101-0000-0000-0000-000000000000";
 
     Characteristic.CareFilter = function () {
-      Characteristic.call(this, 'Care indicator filter', '00000102-0000-0000-0000-000000000000');
+      Characteristic.call(
+        this,
+        "Care indicator filter",
+        "00000102-0000-0000-0000-000000000000"
+      );
       this.setProps({
         format: Characteristic.Formats.FLOAT,
-        unit: '%',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+        unit: "%",
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
       });
       this.value = this.getDefaultValue();
     };
     util.inherits(Characteristic.CareFilter, Characteristic);
-    Characteristic.CareFilter.UUID = '00000102-0000-0000-0000-000000000000';
+    Characteristic.CareFilter.UUID = "00000102-0000-0000-0000-000000000000";
 
     Characteristic.CareSideBrush = function () {
-      Characteristic.call(this, 'Care indicator side brush', '00000103-0000-0000-0000-000000000000');
+      Characteristic.call(
+        this,
+        "Care indicator side brush",
+        "00000103-0000-0000-0000-000000000000"
+      );
       this.setProps({
         format: Characteristic.Formats.FLOAT,
-        unit: '%',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+        unit: "%",
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
       });
       this.value = this.getDefaultValue();
     };
     util.inherits(Characteristic.CareSideBrush, Characteristic);
-    Characteristic.CareSideBrush.UUID = '00000103-0000-0000-0000-000000000000';
+    Characteristic.CareSideBrush.UUID = "00000103-0000-0000-0000-000000000000";
 
     Characteristic.CareMainBrush = function () {
-      Characteristic.call(this, 'Care indicator main brush', '00000104-0000-0000-0000-000000000000');
+      Characteristic.call(
+        this,
+        "Care indicator main brush",
+        "00000104-0000-0000-0000-000000000000"
+      );
       this.setProps({
         format: Characteristic.Formats.FLOAT,
-        unit: '%',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+        unit: "%",
+        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
       });
       this.value = this.getDefaultValue();
     };
     util.inherits(Characteristic.CareMainBrush, Characteristic);
-    Characteristic.CareMainBrush.UUID = '00000104-0000-0000-0000-000000000000';
+    Characteristic.CareMainBrush.UUID = "00000104-0000-0000-0000-000000000000";
 
     Service.Care = function (displayName, subtype) {
-      Service.call(this, displayName, '00000111-0000-0000-0000-000000000000', subtype);
+      Service.call(
+        this,
+        displayName,
+        "00000111-0000-0000-0000-000000000000",
+        subtype
+      );
       this.addCharacteristic(Characteristic.CareSensors);
       this.addCharacteristic(Characteristic.CareFilter);
       this.addCharacteristic(Characteristic.CareSideBrush);
       this.addCharacteristic(Characteristic.CareMainBrush);
     };
     util.inherits(Service.Care, Service);
-    Service.Care.UUID = '00000111-0000-0000-0000-000000000000';
+    Service.Care.UUID = "00000111-0000-0000-0000-000000000000";
 
-    this.services.Care = new Service.Care(`${this.config.name} Care`)
-    this.services.Care
-      .getCharacteristic(Characteristic.CareSensors)
-      .on('get', (cb) => callbackify(() => this.getCareSensors(), cb));
-    this.services.Care
-      .getCharacteristic(Characteristic.CareFilter)
-      .on('get', (cb) => callbackify(() => this.getCareFilter(), cb));
-    this.services.Care
-      .getCharacteristic(Characteristic.CareSideBrush)
-      .on('get', (cb) => callbackify(() => this.getCareSideBrush(), cb));
-    this.services.Care
-      .getCharacteristic(Characteristic.CareMainBrush)
-      .on('get', (cb) => callbackify(() => this.getCareMainBrush(), cb));
+    this.services.Care = new Service.Care(`${this.config.name} Care`);
+    this.services.Care.getCharacteristic(Characteristic.CareSensors).on(
+      "get",
+      (cb) => callbackify(() => this.getCareSensors(), cb)
+    );
+    this.services.Care.getCharacteristic(Characteristic.CareFilter).on(
+      "get",
+      (cb) => callbackify(() => this.getCareFilter(), cb)
+    );
+    this.services.Care.getCharacteristic(Characteristic.CareSideBrush).on(
+      "get",
+      (cb) => callbackify(() => this.getCareSideBrush(), cb)
+    );
+    this.services.Care.getCharacteristic(Characteristic.CareMainBrush).on(
+      "get",
+      (cb) => callbackify(() => this.getCareMainBrush(), cb)
+    );
   }
 
   /**
    * Returns if the newValue is different to the previously cached one
-   * 
+   *
    * @param {string} property
    * @param {any} newValue
    * @returns {boolean} Whether the newValue is not the same as the previously cached one.
@@ -278,110 +344,174 @@ class XiaomiRoborockVacuum {
   }
 
   changedError(robotError) {
-    robotError = robotError || { id: 'unknown', description: `unknown: "${robotError}"` };
-    this.log.debug(`DEB changedError | ${this.model} | ErrorID: ${robotError.id}, ErrorDescription: ${robotError.description}`);
-    let robotErrorTxt = XiaomiRoborockVacuum.errors[`id${robotError.id}`] ?
-      XiaomiRoborockVacuum.errors[`id${robotError.id}`].description :
-      `Unknown ERR | errorid can't be mapped. (${robotError.id})`;
-    if (!`${robotError.description}`.toLowerCase().startsWith('unknown')) {
+    robotError = robotError || {
+      id: "unknown",
+      description: `unknown: "${robotError}"`,
+    };
+    this.log.debug(
+      `DEB changedError | ${this.model} | ErrorID: ${robotError.id}, ErrorDescription: ${robotError.description}`
+    );
+    let robotErrorTxt = XiaomiRoborockVacuum.errors[`id${robotError.id}`]
+      ? XiaomiRoborockVacuum.errors[`id${robotError.id}`].description
+      : `Unknown ERR | errorid can't be mapped. (${robotError.id})`;
+    if (!`${robotError.description}`.toLowerCase().startsWith("unknown")) {
       robotErrorTxt = robotError.description;
     }
-    this.log.warn(`WAR changedError | ${this.model} | Robot has an ERROR - ${robotError.id}, ${robotErrorTxt}`);
+    this.log.warn(
+      `WAR changedError | ${this.model} | Robot has an ERROR - ${robotError.id}, ${robotErrorTxt}`
+    );
   }
 
   changedCleaning(isCleaning) {
-    if (this.isNewValue('cleaning', isCleaning)) {
-      this.log.debug(`MON changedCleaning | ${this.model} | CleaningState is now ${isCleaning}`);
-      this.log.info(`INF changedCleaning | ${this.model} | Cleaning is ${isCleaning ? 'ON' : 'OFF'}.`);
+    if (this.isNewValue("cleaning", isCleaning)) {
+      this.log.debug(
+        `MON changedCleaning | ${this.model} | CleaningState is now ${isCleaning}`
+      );
+      this.log.info(
+        `INF changedCleaning | ${this.model} | Cleaning is ${
+          isCleaning ? "ON" : "OFF"
+        }.`
+      );
     }
     // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
-    this.services.fan.getCharacteristic(Characteristic.On).updateValue(isCleaning);
+    this.services.fan
+      .getCharacteristic(Characteristic.On)
+      .updateValue(isCleaning);
   }
 
   changedPause(isCleaning) {
     if (this.config.pause) {
-      if (this.isNewValue('pause', isCleaning)) {
-        this.log.debug(`MON changedPause | ${this.model} | CleaningState is now ${isCleaning}`);
-        this.log.info(`INF changedPause | ${this.model} | ${isCleaning ? 'Paused possible' : 'Paused not possible, no cleaning'}`);
+      if (this.isNewValue("pause", isCleaning)) {
+        this.log.debug(
+          `MON changedPause | ${this.model} | CleaningState is now ${isCleaning}`
+        );
+        this.log.info(
+          `INF changedPause | ${this.model} | ${
+            isCleaning ? "Paused possible" : "Paused not possible, no cleaning"
+          }`
+        );
       }
       // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
-      this.services.pause.getCharacteristic(Characteristic.On).updateValue(isCleaning);
+      this.services.pause
+        .getCharacteristic(Characteristic.On)
+        .updateValue(isCleaning);
     }
   }
 
   changedCharging(isCharging) {
-    const isNewValue = this.isNewValue('charging', isCharging);
+    const isNewValue = this.isNewValue("charging", isCharging);
     if (isNewValue) {
-      this.log.info(`MON changedCharging | ${this.model} | ChargingState is now ${isCharging}`);
-      this.log.info(`INF changedCharging | ${this.model} | Charging is ${isCharging ? 'active' : 'cancelled'}`);
+      this.log.info(
+        `MON changedCharging | ${this.model} | ChargingState is now ${isCharging}`
+      );
+      this.log.info(
+        `INF changedCharging | ${this.model} | Charging is ${
+          isCharging ? "active" : "cancelled"
+        }`
+      );
     }
     // We still update the value in Homebridge. If we are calling the changed method is because we want to change it.
-    this.services.battery.getCharacteristic(Characteristic.ChargingState).updateValue(isCharging ? Characteristic.ChargingState.CHARGING : Characteristic.ChargingState.NOT_CHARGING);
+    this.services.battery
+      .getCharacteristic(Characteristic.ChargingState)
+      .updateValue(
+        isCharging
+          ? Characteristic.ChargingState.CHARGING
+          : Characteristic.ChargingState.NOT_CHARGING
+      );
     if (this.config.dock) {
       if (isNewValue) {
-        const msg = isCharging ? 'Robot was docked' : 'Robot not anymore in dock';
+        const msg = isCharging
+          ? "Robot was docked"
+          : "Robot not anymore in dock";
         this.log.info(`INF changedCharging | ${this.model} | ${msg}.`);
       }
-      this.services.dock.getCharacteristic(Characteristic.OccupancyDetected).updateValue(isCharging);
+      this.services.dock
+        .getCharacteristic(Characteristic.OccupancyDetected)
+        .updateValue(isCharging);
     }
   }
 
   changedSpeed(speed) {
-    const isNewValue = this.isNewValue('speed', speed);
+    const isNewValue = this.isNewValue("speed", speed);
     if (isNewValue) {
-      this.log.info(`MON changedSpeed | ${this.model} | FanSpeed is now ${speed}%`);
+      this.log.info(
+        `MON changedSpeed | ${this.model} | FanSpeed is now ${speed}%`
+      );
     }
 
     const speedMode = this.findSpeedModeFromMiio(speed);
 
     if (typeof speedMode === "undefined") {
-      this.log.warn(`WAR changedSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`);
+      this.log.warn(
+        `WAR changedSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`
+      );
     } else {
       const { homekitTopLevel, name } = speedMode;
       if (isNewValue) {
-        this.log.info(`INF changedSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`);
+        this.log.info(
+          `INF changedSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`
+        );
       }
-      this.services.fan.getCharacteristic(Characteristic.RotationSpeed).updateValue(homekitTopLevel);
+      this.services.fan
+        .getCharacteristic(Characteristic.RotationSpeed)
+        .updateValue(homekitTopLevel);
     }
   }
 
   changedBattery(level) {
-    this.log.debug(`DEB changedBattery | ${this.model} | BatteryLevel ${level}%`);
-    this.services.battery.getCharacteristic(Characteristic.BatteryLevel).updateValue(level);
-    this.services.battery.getCharacteristic(Characteristic.StatusLowBattery).updateValue((level < 20) ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+    this.log.debug(
+      `DEB changedBattery | ${this.model} | BatteryLevel ${level}%`
+    );
+    this.services.battery
+      .getCharacteristic(Characteristic.BatteryLevel)
+      .updateValue(level);
+    this.services.battery
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .updateValue(
+        level < 20
+          ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
+          : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL
+      );
   }
 
   async initializeDevice() {
-    this.log.debug('DEB getDevice | Discovering vacuum cleaner');
+    this.log.debug("DEB getDevice | Discovering vacuum cleaner");
 
     const device = await miio.device({
       address: this.config.ip,
       token: this.config.token,
     });
 
-    if (device.matches('type:vaccuum')) {
+    if (device.matches("type:vaccuum")) {
       this.device = device;
 
       this.model = this.device.miioModel;
       this.services.info.setCharacteristic(Characteristic.Model, this.model);
 
-      this.log.info('STA getDevice | Connected to: %s', this.config.ip);
-      this.log.info('STA getDevice | Model: ' + this.device.miioModel);
-      this.log.info('STA getDevice | State: ' + this.device.property("state"));
-      this.log.info('STA getDevice | FanSpeed: ' + this.device.property("fanSpeed"));
-      this.log.info('STA getDevice | BatteryLevel: ' + this.device.property("batteryLevel"));
+      this.log.info("STA getDevice | Connected to: %s", this.config.ip);
+      this.log.info("STA getDevice | Model: " + this.device.miioModel);
+      this.log.info("STA getDevice | State: " + this.device.property("state"));
+      this.log.info(
+        "STA getDevice | FanSpeed: " + this.device.property("fanSpeed")
+      );
+      this.log.info(
+        "STA getDevice | BatteryLevel: " + this.device.property("batteryLevel")
+      );
 
       if (this.config.autoroom) {
         if (Array.isArray(this.config.autoroom)) {
-           await this.getRoomList();
+          await this.getRoomList();
         } else {
-           await this.getRoomMap();
+          await this.getRoomMap();
         }
       }
 
       try {
         const serial = await this.getSerialNumber();
-        this.services.info.setCharacteristic(Characteristic.SerialNumber, `${serial}`);
+        this.services.info.setCharacteristic(
+          Characteristic.SerialNumber,
+          `${serial}`
+        );
         this.log.info(`STA getDevice | Serialnumber: ${serial}`);
       } catch (err) {
         this.log.error(`ERR getDevice | get_serial_number | ${err}`);
@@ -390,47 +520,63 @@ class XiaomiRoborockVacuum {
       try {
         const firmware = await this.getFirmware();
         this.firmware = firmware;
-        this.services.info.setCharacteristic(Characteristic.FirmwareRevision, `${firmware}`);
+        this.services.info.setCharacteristic(
+          Characteristic.FirmwareRevision,
+          `${firmware}`
+        );
         this.log.info(`STA getDevice | Firmwareversion: ${firmware}`);
       } catch (err) {
         this.log.error(`ERR getDevice | miIO.info | ${err}`);
       }
 
-      this.device.on('errorChanged', (error) => this.changedError(error));
-      this.device.on('stateChanged', (state) => {
-        if (state.key === 'cleaning') {
+      this.device.on("errorChanged", (error) => this.changedError(error));
+      this.device.on("stateChanged", (state) => {
+        if (state.key === "cleaning") {
           this.changedCleaning(state.value);
           this.changedPause(state.value);
-        } else if (state.key === 'charging') {
+        } else if (state.key === "charging") {
           this.changedCharging(state.value);
-        } else if (state.key === 'fanSpeed') {
+        } else if (state.key === "fanSpeed") {
           this.changedSpeed(state.value);
-        } else if (state.key === 'batteryLevel') {
+        } else if (state.key === "batteryLevel") {
           this.changedBattery(state.value);
         } else {
-          this.log.debug(`DEB stateChanged | ${this.model} | Not supported stateChanged event: ${state.key}:${state.value}`);
+          this.log.debug(
+            `DEB stateChanged | ${this.model} | Not supported stateChanged event: ${state.key}:${state.value}`
+          );
         }
       });
 
       await this.getState();
       // Refresh the state every 30s so miio maintains a fresh connection (or recovers connection if lost until we fix https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/81)
       clearInterval(this.getStateInterval);
-      this.getStateInterval = setInterval(() => this.getState(), GET_STATE_INTERVAL_MS);
+      this.getStateInterval = setInterval(
+        () => this.getState(),
+        GET_STATE_INTERVAL_MS
+      );
     } else {
       const model = (device || {}).miioModel;
-      this.log.error(`ERR getDevice | Device "${model}" is not registered as a vacuum cleaner! If you think it should be, please open an issue at https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/new and provide this line.`);
+      this.log.error(
+        `ERR getDevice | Device "${model}" is not registered as a vacuum cleaner! If you think it should be, please open an issue at https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/new and provide this line.`
+      );
       this.log.debug(device);
       device.destroy();
     }
   }
 
   async connect() {
-    if (this.connectingPromise === null) { // if already trying to connect, don't trigger yet another one
+    if (this.connectingPromise === null) {
+      // if already trying to connect, don't trigger yet another one
       this.connectingPromise = this.initializeDevice().catch((error) => {
-        this.log.error(`ERR connect | miio.device, next try in 2 minutes | ${error}`);
+        this.log.error(
+          `ERR connect | miio.device, next try in 2 minutes | ${error}`
+        );
         clearTimeout(this.connectRetry);
         // Using setTimeout instead of holding the promise. This way we'll keep retrying but not holding the other actions
-        this.connectRetry = setTimeout(() => this.connect().catch(() => {}), 120000);
+        this.connectRetry = setTimeout(
+          () => this.connect().catch(() => {}),
+          120000
+        );
         throw error;
       });
     }
@@ -453,10 +599,17 @@ class XiaomiRoborockVacuum {
       // checking if the device has an open socket it will fail retrieving it if not
       // https://github.com/aholstenson/miio/blob/master/lib/network.js#L227
       const socket = this.device.handle.api.parent.socket;
-      this.log.debug(`DEB ensureDevice | ${this.model} | The socket is still on. Reusing it.`);
+      this.log.debug(
+        `DEB ensureDevice | ${this.model} | The socket is still on. Reusing it.`
+      );
     } catch (err) {
-      if (/destroyed/i.test(err.message) || /No vacuum cleaner is discovered yet/.test(err.message)) {
-        this.log.info(`INF ensureDevice | ${this.model} | The socket was destroyed or not initialised, initialising the device`);
+      if (
+        /destroyed/i.test(err.message) ||
+        /No vacuum cleaner is discovered yet/.test(err.message)
+      ) {
+        this.log.info(
+          `INF ensureDevice | ${this.model} | The socket was destroyed or not initialised, initialising the device`
+        );
         await this.connect();
       } else {
         this.log.error(err);
@@ -467,17 +620,21 @@ class XiaomiRoborockVacuum {
 
   async getState() {
     try {
-      await this.ensureDevice('getState');
+      await this.ensureDevice("getState");
       const state = await this.device.state();
       this.log.debug(`DEB getState | ${this.model} | State %j`, state);
-      
+
       safeCall(state.cleaning, (cleaning) => this.changedCleaning(cleaning));
       safeCall(state.charging, (charging) => this.changedCharging(charging));
       safeCall(state.fanSpeed, (fanSpeed) => this.changedSpeed(fanSpeed));
-      safeCall(state.batteryLevel, (batteryLevel) => this.changedBattery(batteryLevel));
+      safeCall(state.batteryLevel, (batteryLevel) =>
+        this.changedBattery(batteryLevel)
+      );
       safeCall(state.cleaning, (cleaning) => this.changedPause(cleaning));
       if (this.config.waterBox) {
-        safeCall(state['water_box_mode'], (waterBoxMode) => this.changedWaterSpeed(waterBoxMode));
+        safeCall(state["water_box_mode"], (waterBoxMode) =>
+          this.changedWaterSpeed(waterBoxMode)
+        );
       }
 
       // No need to throw the error at this point. This are just warnings like (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/91)
@@ -488,168 +645,228 @@ class XiaomiRoborockVacuum {
   }
 
   async getSerialNumber() {
-    await this.ensureDevice('getSerialNumber');
+    await this.ensureDevice("getSerialNumber");
 
     try {
-      const serial = await this.device.call('get_serial_number');
-      this.log.info(`INF getSerialNumber | ${this.model} | Serial Number is ${serial[0].serial_number}`);
+      const serial = await this.device.call("get_serial_number");
+      this.log.info(
+        `INF getSerialNumber | ${this.model} | Serial Number is ${serial[0].serial_number}`
+      );
 
       return serial[0].serial_number;
     } catch (err) {
-      this.log.error(`ERR getSerialNumber | Failed getting the firmware version.`, err);
+      this.log.error(
+        `ERR getSerialNumber | Failed getting the firmware version.`,
+        err
+      );
       throw err;
     }
   }
 
   async getFirmware() {
-    await this.ensureDevice('getFirmware');
+    await this.ensureDevice("getFirmware");
 
     try {
-      const firmware = await this.device.call('miIO.info');
-      this.log.info(`INF getFirmware | ${this.model} | Firmwareversion is ${firmware.fw_ver}`);
+      const firmware = await this.device.call("miIO.info");
+      this.log.info(
+        `INF getFirmware | ${this.model} | Firmwareversion is ${firmware.fw_ver}`
+      );
 
       return firmware.fw_ver;
     } catch (err) {
-      this.log.error(`ERR getFirmware | Failed getting the firmware version.`, err);
+      this.log.error(
+        `ERR getFirmware | Failed getting the firmware version.`,
+        err
+      );
       throw err;
     }
   }
 
   get isCleaning() {
-    const status = this.device.property('state');
+    const status = this.device.property("state");
     return XiaomiRoborockVacuum.cleaningStatuses.includes(status);
   }
 
   async getCleaning() {
-    await this.ensureDevice('getCleaning');
+    await this.ensureDevice("getCleaning");
 
     try {
-      const isCleaning = this.isCleaning
-      this.log.info(`INF getCleaning | ${this.model} | Cleaning is ${isCleaning}`);
+      const isCleaning = this.isCleaning;
+      this.log.info(
+        `INF getCleaning | ${this.model} | Cleaning is ${isCleaning}`
+      );
 
       return isCleaning;
     } catch (err) {
-      this.log.error(`ERR getCleaning | Failed getting the cleaning status.`, err);
+      this.log.error(
+        `ERR getCleaning | Failed getting the cleaning status.`,
+        err
+      );
       throw err;
     }
   }
 
   async setCleaning(state) {
-    await this.ensureDevice('setCleaning');
+    await this.ensureDevice("setCleaning");
 
     try {
-      if (state && !this.isCleaning) { // Start cleaning
-        this.log.info(`ACT setCleaning | ${this.model} | Start cleaning, not charging.`);
+      if (state && !this.isCleaning) {
+        // Start cleaning
+        this.log.info(
+          `ACT setCleaning | ${this.model} | Start cleaning, not charging.`
+        );
         await this.device.activateCleaning();
-      } else if (!state) { // Stop cleaning
-        this.log.info(`ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`);
+      } else if (!state) {
+        // Stop cleaning
+        this.log.info(
+          `ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`
+        );
         await this.activateCharging(); // Charging works for 1st, not for 2nd
       }
     } catch (err) {
-      this.log.error(`ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`, err);
+      this.log.error(
+        `ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`,
+        err
+      );
       throw err;
     }
   }
 
   async setCleaningRoom(state, room) {
-    await this.ensureDevice('setCleaning');
+    await this.ensureDevice("setCleaning");
 
     try {
-      if (state && !this.isCleaning) { // Start cleaning
-        this.log.info(`ACT setCleaning | ${this.model} | Start cleaning Room ID ${room}, not charging.`);
+      if (state && !this.isCleaning) {
+        // Start cleaning
+        this.log.info(
+          `ACT setCleaning | ${this.model} | Start cleaning Room ID ${room}, not charging.`
+        );
         const refreshState = {
-          refresh: [ 'state' ],
-          refreshDelay: 1000
+          refresh: ["state"],
+          refreshDelay: 1000,
         };
-        await this.device.call('app_segment_clean', [room], refreshState);
-      } else if (!state) { // Stop cleaning
-        this.log.info(`ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`);
+        await this.device.call("app_segment_clean", [room], refreshState);
+      } else if (!state) {
+        // Stop cleaning
+        this.log.info(
+          `ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`
+        );
         await this.activateCharging();
       }
     } catch (err) {
-      this.log.error(`ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`, err);
+      this.log.error(
+        `ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`,
+        err
+      );
       throw err;
     }
   }
 
   async setCleaningZone(state, zone) {
-    await this.ensureDevice('setCleaning');
+    await this.ensureDevice("setCleaning");
 
     try {
-      if (state && !this.isCleaning) { // Start cleaning
-        this.log.info(`ACT setCleaning | ${this.model} | Start cleaning Zone ${zone}, not charging.`);
+      if (state && !this.isCleaning) {
+        // Start cleaning
+        this.log.info(
+          `ACT setCleaning | ${this.model} | Start cleaning Zone ${zone}, not charging.`
+        );
         const refreshState = {
-          refresh: [ 'state' ],
-          refreshDelay: 1000
+          refresh: ["state"],
+          refreshDelay: 1000,
         };
-        
+
         var zoneParams = [];
         for (var zon of zone) {
           if (zon.length == 4) {
-              zoneParams.push(zon.concat(1));
+            zoneParams.push(zon.concat(1));
           } else if (zon.length == 5) {
-              zoneParams.push(zon);
+            zoneParams.push(zon);
           }
         }
-        await this.device.call('app_zoned_clean',zoneParams,refreshState);
-      } else if (!state) { // Stop cleaning
-        this.log.info(`ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`);
+        await this.device.call("app_zoned_clean", zoneParams, refreshState);
+      } else if (!state) {
+        // Stop cleaning
+        this.log.info(
+          `ACT setCleaning | ${this.model} | Stop cleaning and go to charge.`
+        );
         await this.activateCharging();
       }
     } catch (err) {
-      this.log.error(`ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`, err);
+      this.log.error(
+        `ERR setCleaning | ${this.model} | Failed to set cleaning to ${state}`,
+        err
+      );
       throw err;
     }
   }
 
   async activateCharging() {
-    await this.ensureDevice('activateCharging');
+    await this.ensureDevice("activateCharging");
     try {
       const refreshState = {
-        refresh: [ 'state' ],
-        refreshDelay: 1000
+        refresh: ["state"],
+        refreshDelay: 1000,
       };
-      await this.device.call('app_stop', [], refreshState);
+      await this.device.call("app_stop", [], refreshState);
       // Wait one second before calling go to charge
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      const changeResponse = await this.device.call('app_charge', [], refreshState);
-      if (!(changeResponse && changeResponse[0] === 'ok')) {
-        throw new Error('Failed to go to change');
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const changeResponse = await this.device.call(
+        "app_charge",
+        [],
+        refreshState
+      );
+      if (!(changeResponse && changeResponse[0] === "ok")) {
+        throw new Error("Failed to go to change");
       }
     } catch (err) {
-      this.log.error(`ERR setCharging | ${this.model} | Failed to go charging.`, err);
+      this.log.error(
+        `ERR setCharging | ${this.model} | Failed to go charging.`,
+        err
+      );
       throw err;
     }
   }
 
   async getRoomList() {
-    await this.ensureDevice('getRoomList');
+    await this.ensureDevice("getRoomList");
 
     try {
-      const timers = await this.device.call('get_timer');
+      const timers = await this.device.call("get_timer");
 
       // Find specific timer containing the room order
       // Timer needs to be scheduled for 00:00 and inactive
       let leetTimer = timers.find(
-        x => x[2][0].startsWith("0 0") && x[1] == 'off');
+        (x) => x[2][0].startsWith("0 0") && x[1] == "off"
+      );
       if (leetTimer == undefined) {
-        this.log.error(`ERR getRoomList | ${this.model} | Could not find a timer for autoroom`);
+        this.log.error(
+          `ERR getRoomList | ${this.model} | Could not find a timer for autoroom`
+        );
         return;
       }
 
-      let roomIds = leetTimer[2][1][1]['segments'].split(`,`).map(x=>+x);
-      this.log.debug(`DEB getRoomList | ${this.model} | Room IDs are ${roomIds}`);
+      let roomIds = leetTimer[2][1][1]["segments"].split(`,`).map((x) => +x);
+      this.log.debug(
+        `DEB getRoomList | ${this.model} | Room IDs are ${roomIds}`
+      );
 
       if (roomIds.length != this.config.autoroom.length) {
-        this.log.error(`ERR getRoomList | ${this.model} | Number of rooms in config does not match number of rooms in the timer`);
+        this.log.error(
+          `ERR getRoomList | ${this.model} | Number of rooms in config does not match number of rooms in the timer`
+        );
         return;
       }
       let roomMap = [];
       for (const [i, roomId] of roomIds.entries()) {
         this.services[this.config.autoroom[i]].roomId = roomId;
-        roomMap.push({'id': roomId, 'name': this.config.autoroom[i]});
+        roomMap.push({ id: roomId, name: this.config.autoroom[i] });
       }
-      this.log.info(`INF getRoomList | ${this.model} | Created "rooms": ${JSON.stringify(roomMap)}`);
+      this.log.info(
+        `INF getRoomList | ${this.model} | Created "rooms": ${JSON.stringify(
+          roomMap
+        )}`
+      );
     } catch (err) {
       this.log.error(`ERR getRoomList | Failed getting the Room List.`, err);
       throw err;
@@ -657,12 +874,12 @@ class XiaomiRoborockVacuum {
   }
 
   async getRoomMap() {
-    await this.ensureDevice('getRoomMap');
+    await this.ensureDevice("getRoomMap");
 
     try {
-      const map = await this.device.call('get_room_mapping');
+      const map = await this.device.call("get_room_mapping");
       this.log.info(`INF getRoomMap | ${this.model} | Map is ${map}`);
-      for(let val of map) {
+      for (let val of map) {
         this.createRoom(val[0], val[1]);
       }
     } catch (err) {
@@ -672,34 +889,52 @@ class XiaomiRoborockVacuum {
   }
 
   createRoom(roomId, roomName) {
-    this.log.info(`INF createRoom | ${this.model} | Room ${roomName} (${roomId})`);
-    this.services[roomName] = new Service.Switch(`${this.config.cleanword} ${roomName}`,'roomService' + roomId);
+    this.log.info(
+      `INF createRoom | ${this.model} | Room ${roomName} (${roomId})`
+    );
+    this.services[roomName] = new Service.Switch(
+      `${this.config.cleanword} ${roomName}`,
+      "roomService" + roomId
+    );
     this.services[roomName].roomId = roomId;
     this.services[roomName]
-    .getCharacteristic(Characteristic.On)
-    .on('get', (cb) => callbackify(() => this.getCleaning(), cb))
-    .on('set', (newState, cb) => callbackify(() => this.setCleaningRoom(newState, this.services[roomName].roomId), cb))
-    .on('change', (oldState, newState) => {
-      this.changedPause(newState);
-    });
+      .getCharacteristic(Characteristic.On)
+      .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
+      .on("set", (newState, cb) =>
+        callbackify(
+          () => this.setCleaningRoom(newState, this.services[roomName].roomId),
+          cb
+        )
+      )
+      .on("change", (oldState, newState) => {
+        this.changedPause(newState);
+      });
   }
 
   createZone(zoneName, zoneParams) {
-    this.log.info(`INF createRoom | ${this.model} | Zone ${zoneName} (${zoneParams})`);
-    this.services[zoneName] = new Service.Switch(`${this.config.cleanword} ${zoneName}`,'zoneCleaning' + zoneName);
+    this.log.info(
+      `INF createRoom | ${this.model} | Zone ${zoneName} (${zoneParams})`
+    );
+    this.services[zoneName] = new Service.Switch(
+      `${this.config.cleanword} ${zoneName}`,
+      "zoneCleaning" + zoneName
+    );
     this.services[zoneName]
-    .getCharacteristic(Characteristic.On)
-    .on('get', (cb) => callbackify(() => this.getCleaning(), cb))
-    .on('set', (newState, cb) => callbackify(() => this.setCleaningZone(newState, zoneParams), cb))
-    .on('change', (oldState, newState) => {
-      this.changedPause(newState);
-    });
+      .getCharacteristic(Characteristic.On)
+      .on("get", (cb) => callbackify(() => this.getCleaning(), cb))
+      .on("set", (newState, cb) =>
+        callbackify(() => this.setCleaningZone(newState, zoneParams), cb)
+      )
+      .on("change", (oldState, newState) => {
+        this.changedPause(newState);
+      });
   }
 
   findSpeedModes() {
     return (MODELS[this.model] || []).reduce((acc, option) => {
       if (option.firmware) {
-        const [,cleanFirmware] = (this.firmware || '').match(/^(\d+\.\d+\.\d+)/) || [];
+        const [, cleanFirmware] =
+          (this.firmware || "").match(/^(\d+\.\d+\.\d+)/) || [];
         return semver.satisfies(cleanFirmware, option.firmware) ? option : acc;
       } else {
         return option;
@@ -716,35 +951,50 @@ class XiaomiRoborockVacuum {
   }
 
   async getSpeed() {
-    await this.ensureDevice('getSpeed');
+    await this.ensureDevice("getSpeed");
 
-    const speed = this.device.property('fanSpeed');
-    this.log.info(`INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO. Converting to HomeKit`)
+    const speed = this.device.property("fanSpeed");
+    this.log.info(
+      `INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO. Converting to HomeKit`
+    );
 
     const { homekitTopLevel, name } = this.findSpeedModeFromMiio(speed);
 
-    this.log.info(`INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`);
+    this.log.info(
+      `INF getSpeed | ${this.model} | Fanspeed is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`
+    );
     return homekitTopLevel || 0;
   }
 
   async setSpeed(speed) {
-    await this.ensureDevice('setSpeed');
+    await this.ensureDevice("setSpeed");
 
-    this.log.debug(`ACT setSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`);
+    this.log.debug(
+      `ACT setSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`
+    );
 
     // Get the speed modes for this model
     const speedModes = this.findSpeedModes().speed;
 
     // gen1 has maximum of 91%, so anything over that won't work. Getting safety maximum.
-    const safeSpeed = Math.min(parseInt(speed), speedModes[speedModes.length - 1].homekitTopLevel);
+    const safeSpeed = Math.min(
+      parseInt(speed),
+      speedModes[speedModes.length - 1].homekitTopLevel
+    );
 
     // Find the minimum homekitTopLevel that matches the desired speed
-    const { miLevel, name } = speedModes.find((mode) => safeSpeed <= mode.homekitTopLevel);
+    const { miLevel, name } = speedModes.find(
+      (mode) => safeSpeed <= mode.homekitTopLevel
+    );
 
-    this.log.info(`ACT setSpeed | ${this.model} | FanSpeed set to ${miLevel} over miIO for "${name}".`);
+    this.log.info(
+      `ACT setSpeed | ${this.model} | FanSpeed set to ${miLevel} over miIO for "${name}".`
+    );
 
     if (miLevel === 0) {
-      this.log.debug(`DEB setSpeed | ${this.model} | FanSpeed is 0 => Calling setCleaning(false) instead of changing the fan speed`);
+      this.log.debug(
+        `DEB setSpeed | ${this.model} | FanSpeed is 0 => Calling setCleaning(false) instead of changing the fan speed`
+      );
       await this.setCleaning(false);
     } else {
       await this.device.changeFanSpeed(miLevel);
@@ -761,10 +1011,12 @@ class XiaomiRoborockVacuum {
 
   async getWaterSpeedInDevice() {
     // From https://github.com/marcelrv/XiaomiRobotVacuumProtocol/blob/master/water_box_custom_mode.md
-    const response = await this.device.call('get_water_box_custom_mode', [ ], { refresh : [ 'water_box_mode' ] });
+    const response = await this.device.call("get_water_box_custom_mode", [], {
+      refresh: ["water_box_mode"],
+    });
     // From https://github.com/nicoh88/miio/blob/master/lib/devices/vacuum.js#L11-L18
     const [waterMode] = response || [];
-    if ( typeof waterMode === undefined ) {
+    if (typeof waterMode === undefined) {
       this.log.error(response);
       throw new Error(`Failed to get the water_box_mode`);
     }
@@ -772,84 +1024,119 @@ class XiaomiRoborockVacuum {
   }
 
   async getWaterSpeed() {
-    await this.ensureDevice('getWaterSpeed');
+    await this.ensureDevice("getWaterSpeed");
 
-    
     const speed = await this.getWaterSpeedInDevice();
-    this.log.info(`INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO. Converting to HomeKit`)
+    this.log.info(
+      `INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO. Converting to HomeKit`
+    );
 
     const waterSpeed = this.findWaterSpeedModeFromMiio(speed);
 
-    let homekitValue = 0
+    let homekitValue = 0;
     if (waterSpeed) {
-      const { homekitTopLevel, name } = waterSpeed
-      this.log.info(`INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`);
+      const { homekitTopLevel, name } = waterSpeed;
+      this.log.info(
+        `INF getWaterSpeed | ${this.model} | WaterBoxMode is ${speed} over miIO "${name}" > HomeKit speed ${homekitTopLevel}%`
+      );
       homekitValue = homekitTopLevel || 0;
     }
-    this.services.waterBox.getCharacteristic(Characteristic.On).updateValue(homekitValue > 0);
+    this.services.waterBox
+      .getCharacteristic(Characteristic.On)
+      .updateValue(homekitValue > 0);
     return homekitValue;
   }
 
   async setWaterSpeed(speed) {
-    await this.ensureDevice('setWaterSpeed');
+    await this.ensureDevice("setWaterSpeed");
 
-    this.log.debug(`ACT setWaterSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`);
+    this.log.debug(
+      `ACT setWaterSpeed | ${this.model} | Speed got ${speed}% over HomeKit > CLEANUP.`
+    );
 
     // Get the speed modes for this model
     const speedModes = this.findSpeedModes().waterspeed || [];
 
     // If the robot does not support water-mode cleaning
     if (speedModes.length === 0) {
-      this.log.info(`INF setWaterSpeed | ${this.model} | Model does not support the water mode`);
+      this.log.info(
+        `INF setWaterSpeed | ${this.model} | Model does not support the water mode`
+      );
       return;
     }
 
     // gen1 has maximum of 91%, so anything over that won't work. Getting safety maximum.
-    const safeSpeed = Math.min(parseInt(speed), speedModes[speedModes.length - 1].homekitTopLevel);
+    const safeSpeed = Math.min(
+      parseInt(speed),
+      speedModes[speedModes.length - 1].homekitTopLevel
+    );
 
     // Find the minimum homekitTopLevel that matches the desired speed
-    const { miLevel, name } = speedModes.find((mode) => safeSpeed <= mode.homekitTopLevel);
+    const { miLevel, name } = speedModes.find(
+      (mode) => safeSpeed <= mode.homekitTopLevel
+    );
 
-    this.log.info(`ACT setWaterSpeed | ${this.model} | WaterBoxMode set to ${miLevel} over miIO for "${name}".`);
+    this.log.info(
+      `ACT setWaterSpeed | ${this.model} | WaterBoxMode set to ${miLevel} over miIO for "${name}".`
+    );
 
     // From https://github.com/marcelrv/XiaomiRobotVacuumProtocol/blob/master/water_box_custom_mode.md
-    const response = await this.device.call('set_water_box_custom_mode', [ miLevel ], { refresh : [ 'water_box_mode' ] });
+    const response = await this.device.call(
+      "set_water_box_custom_mode",
+      [miLevel],
+      { refresh: ["water_box_mode"] }
+    );
     // From https://github.com/nicoh88/miio/blob/master/lib/devices/vacuum.js#L11-L18
-    if ( response !== 0 && response[0] !== 'ok' ) {
+    if (response !== 0 && response[0] !== "ok") {
       this.log.error(response);
       throw new Error(`Failed to set the water_box_mode to ${miLevel}`);
     }
   }
 
   changedWaterSpeed(speed) {
-    this.log.info(`MON changedWaterSpeed | ${this.model} | WaterBoxMode is now ${speed}%`);
+    this.log.info(
+      `MON changedWaterSpeed | ${this.model} | WaterBoxMode is now ${speed}%`
+    );
 
     const speedMode = this.findWaterSpeedModeFromMiio(speed);
 
     if (typeof speedMode === "undefined") {
-      this.log.warn(`WAR changedWaterSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`);
+      this.log.warn(
+        `WAR changedWaterSpeed | ${this.model} | Speed was changed to ${speed}%, this speed is not supported`
+      );
     } else {
       const { homekitTopLevel, name } = speedMode;
-      this.log.info(`INF changedWaterSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`);
-      this.services.waterBox.getCharacteristic(Characteristic.RotationSpeed).updateValue(homekitTopLevel);
-      this.services.waterBox.getCharacteristic(Characteristic.On).updateValue(homekitTopLevel > 0)
+      this.log.info(
+        `INF changedWaterSpeed | ${this.model} | Speed was changed to ${speed}% (${name}), for HomeKit ${homekitTopLevel}%`
+      );
+      this.services.waterBox
+        .getCharacteristic(Characteristic.RotationSpeed)
+        .updateValue(homekitTopLevel);
+      this.services.waterBox
+        .getCharacteristic(Characteristic.On)
+        .updateValue(homekitTopLevel > 0);
     }
   }
 
   async getPauseState() {
-    await this.ensureDevice('getPauseState');
+    await this.ensureDevice("getPauseState");
 
     try {
-      const isCleaning = this.isCleaning
-      this.log.info(`INF getPauseState | ${this.model} | Pause possible is ${isCleaning}`);
+      const isCleaning = this.isCleaning;
+      this.log.info(
+        `INF getPauseState | ${this.model} | Pause possible is ${isCleaning}`
+      );
       return isCleaning;
     } catch (err) {
-      this.log.error(`ERR getPauseState | ${this.model} | Failed getting the cleaning status.`, err);
+      this.log.error(
+        `ERR getPauseState | ${this.model} | Failed getting the cleaning status.`,
+        err
+      );
     }
   }
 
   async setPauseState(state) {
-    await this.ensureDevice('setPauseState');
+    await this.ensureDevice("setPauseState");
 
     try {
       if (state) {
@@ -858,48 +1145,71 @@ class XiaomiRoborockVacuum {
         await this.device.pause();
       }
     } catch (err) {
-      this.log.error(`ERR setPauseState | ${this.model} | Failed updating pause state ${state}.`, err);
+      this.log.error(
+        `ERR setPauseState | ${this.model} | Failed updating pause state ${state}.`,
+        err
+      );
     }
   }
 
   async getCharging() {
-    await this.ensureDevice('getCharging');
+    await this.ensureDevice("getCharging");
 
     // From https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L65
-    const status = this.device.property('state');
-    this.log.info(`INF getCharging | ${this.model} | Charging is ${status === "charging"} (Status is ${status})`);
+    const status = this.device.property("state");
+    this.log.info(
+      `INF getCharging | ${this.model} | Charging is ${
+        status === "charging"
+      } (Status is ${status})`
+    );
 
-    return (status === "charging") ? Characteristic.ChargingState.CHARGING : Characteristic.ChargingState.NOT_CHARGING;
+    return status === "charging"
+      ? Characteristic.ChargingState.CHARGING
+      : Characteristic.ChargingState.NOT_CHARGING;
   }
 
   async getDocked() {
-    await this.ensureDevice('getDocked');
+    await this.ensureDevice("getDocked");
 
     // From https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L65
-    const status = this.device.property('state');
-    this.log.info(`INF getDocked | ${this.model} | Robot Docked is ${status === 'charging'} (Status is ${status})`);
+    const status = this.device.property("state");
+    this.log.info(
+      `INF getDocked | ${this.model} | Robot Docked is ${
+        status === "charging"
+      } (Status is ${status})`
+    );
 
     return status === "charging";
   }
 
   async getBattery() {
-    await this.ensureDevice('getBattery');
+    await this.ensureDevice("getBattery");
 
     // https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L90
-    this.log.info(`INF getBattery | ${this.model} | Batterylevel is ${this.device.property('batteryLevel')}%`);
-    return this.device.property('batteryLevel');
+    this.log.info(
+      `INF getBattery | ${this.model} | Batterylevel is ${this.device.property(
+        "batteryLevel"
+      )}%`
+    );
+    return this.device.property("batteryLevel");
   }
 
   async getBatteryLow() {
-    await this.ensureDevice('getBatteryLow');
+    await this.ensureDevice("getBatteryLow");
 
     // https://github.com/aholstenson/miio/blob/master/lib/devices/vacuum.js#L90
-    this.log.info(`INF getBatteryLow | ${this.model} | Batterylevel is ${this.device.property('batteryLevel')}%`);
-    return (this.device.property('batteryLevel') < 20) ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
+    this.log.info(
+      `INF getBatteryLow | ${
+        this.model
+      } | Batterylevel is ${this.device.property("batteryLevel")}%`
+    );
+    return this.device.property("batteryLevel") < 20
+      ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
+      : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
   }
 
   async identify(callback) {
-    await this.ensureDevice('identify');
+    await this.ensureDevice("identify");
 
     this.log.info(`ACT identify | ${this.model} | Find me - Hello!`);
     try {
@@ -921,49 +1231,78 @@ class XiaomiRoborockVacuum {
     if (sleep) {
       sleep(time);
     } else {
-      this.log.warn(`Can't use the delay option because the module "system-sleep" failed to install.\n
+      this.log
+        .warn(`Can't use the delay option because the module "system-sleep" failed to install.\n
       Make sure this optional dependency is properly installed if you want to use the "delay" option.`);
     }
   }
 
   // CONSUMABLE / CARE
   async getCareSensors() {
-    await this.ensureDevice('getCareSensors');
+    await this.ensureDevice("getCareSensors");
 
     // 30h = sensor_dirty_time
     const lifetime = 108000;
-    const lifetimepercent = this.device.property("sensorDirtyTime") / lifetime * 100;
-    this.log.info(`INF getCareSensors | ${this.model} | Sensors dirtytime is ${this.device.property("sensorDirtyTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
+    const lifetimepercent =
+      (this.device.property("sensorDirtyTime") / lifetime) * 100;
+    this.log.info(
+      `INF getCareSensors | ${
+        this.model
+      } | Sensors dirtytime is ${this.device.property(
+        "sensorDirtyTime"
+      )} seconds / ${lifetimepercent.toFixed(2)}%.`
+    );
     return lifetimepercent;
   }
 
   async getCareFilter() {
-    await this.ensureDevice('getCareFilter');
+    await this.ensureDevice("getCareFilter");
 
     // 150h = filter_work_time
     const lifetime = 540000;
-    const lifetimepercent = this.device.property("filterWorkTime") / lifetime * 100;
-    this.log.info(`INF getCareFilter | ${this.model} | Filter worktime is ${this.device.property("filterWorkTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
+    const lifetimepercent =
+      (this.device.property("filterWorkTime") / lifetime) * 100;
+    this.log.info(
+      `INF getCareFilter | ${
+        this.model
+      } | Filter worktime is ${this.device.property(
+        "filterWorkTime"
+      )} seconds / ${lifetimepercent.toFixed(2)}%.`
+    );
     return lifetimepercent;
   }
 
   async getCareSideBrush() {
-    await this.ensureDevice('getCareSideBrush');
+    await this.ensureDevice("getCareSideBrush");
 
     // 200h = side_brush_work_time
     const lifetime = 720000;
-    const lifetimepercent = this.device.property("sideBrushWorkTime") / lifetime * 100;
-    this.log.info(`INF getCareSideBrush | ${this.model} | Sidebrush worktime is ${this.device.property("sideBrushWorkTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
+    const lifetimepercent =
+      (this.device.property("sideBrushWorkTime") / lifetime) * 100;
+    this.log.info(
+      `INF getCareSideBrush | ${
+        this.model
+      } | Sidebrush worktime is ${this.device.property(
+        "sideBrushWorkTime"
+      )} seconds / ${lifetimepercent.toFixed(2)}%.`
+    );
     return lifetimepercent;
   }
 
   async getCareMainBrush() {
-    await this.ensureDevice('getCareMainBrush');
+    await this.ensureDevice("getCareMainBrush");
 
     // 300h = main_brush_work_time
     const lifetime = 1080000;
-    const lifetimepercent = this.device.property("mainBrushWorkTime") / lifetime * 100;
-    this.log.info(`INF getCareMainBrush | ${this.model} | Mainbrush worktime is ${this.device.property("mainBrushWorkTime")} seconds / ${lifetimepercent.toFixed(2)}%.`);
+    const lifetimepercent =
+      (this.device.property("mainBrushWorkTime") / lifetime) * 100;
+    this.log.info(
+      `INF getCareMainBrush | ${
+        this.model
+      } | Mainbrush worktime is ${this.device.property(
+        "mainBrushWorkTime"
+      )} seconds / ${lifetimepercent.toFixed(2)}%.`
+    );
     return lifetimepercent;
   }
 }

--- a/lib/callbackify.js
+++ b/lib/callbackify.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 module.exports = async function (fn, callback) {
   try {
@@ -7,4 +7,4 @@ module.exports = async function (fn, callback) {
   } catch (err) {
     callback(err);
   }
-}
+};

--- a/lib/safeCall.js
+++ b/lib/safeCall.js
@@ -1,13 +1,13 @@
-'use strict';
+"use strict";
 
 /**
  * Calls the function `fn` if `maybeValue` is not undefined
- * 
+ *
  * @param maybeValue The value that can be undefined
  * @param fn The function to be called with the value as a parameter
  */
 module.exports = async function (maybeValue, fn) {
-  if (typeof maybeValue !== 'undefined') {
+  if (typeof maybeValue !== "undefined") {
     return fn(maybeValue);
   }
-}
+};

--- a/models/index.js
+++ b/models/index.js
@@ -1,3 +1,3 @@
-'use strict';
+"use strict";
 
-module.exports = require('./models');
+module.exports = require("./models");

--- a/models/models.js
+++ b/models/models.js
@@ -1,20 +1,22 @@
-'use strict';
+"use strict";
 
-const speedmodes = require('./speedmodes');
-const watermodes = require('./watermodes');
+const speedmodes = require("./speedmodes");
+const watermodes = require("./watermodes");
 
 module.exports = {
-  'default': {speed: speedmodes.gen1},
-  'rockrobo.vacuum.v1': [{speed: speedmodes.gen1}],
-  'roborock.vacuum.c1': [{speed: speedmodes.gen1}],
-  'roborock.vacuum.m1s': [{speed: speedmodes.gen3}],
-  'roborock.vacuum.s5': [
-    {speed: speedmodes.gen2},
-    {firmware: '>=3.5.7', speed: speedmodes.gen3},
+  default: { speed: speedmodes.gen1 },
+  "rockrobo.vacuum.v1": [{ speed: speedmodes.gen1 }],
+  "roborock.vacuum.c1": [{ speed: speedmodes.gen1 }],
+  "roborock.vacuum.m1s": [{ speed: speedmodes.gen3 }],
+  "roborock.vacuum.s5": [
+    { speed: speedmodes.gen2 },
+    { firmware: ">=3.5.7", speed: speedmodes.gen3 },
   ],
-  'roborock.vacuum.s5e': [{speed: speedmodes["gen4+custom"], waterspeed: watermodes.gen1}],
-  'roborock.vacuum.s6': [{speed: speedmodes.gen4}],
-  'roborock.vacuum.t6': [{speed: speedmodes.gen3}],
-  'roborock.vacuum.t4': [{speed: speedmodes.gen3}],
-  'roborock.vacuum.e2': [{speed: speedmodes.gen3}],
+  "roborock.vacuum.s5e": [
+    { speed: speedmodes["gen4+custom"], waterspeed: watermodes.gen1 },
+  ],
+  "roborock.vacuum.s6": [{ speed: speedmodes.gen4 }],
+  "roborock.vacuum.t6": [{ speed: speedmodes.gen3 }],
+  "roborock.vacuum.t4": [{ speed: speedmodes.gen3 }],
+  "roborock.vacuum.e2": [{ speed: speedmodes.gen3 }],
 };

--- a/models/speedmodes.js
+++ b/models/speedmodes.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 module.exports = {
   gen1: [
@@ -11,7 +11,7 @@ module.exports = {
     // 61-77%  = "Turbo / Stark"
     { homekitTopLevel: 77, miLevel: 77, name: "Turbo" },
     // 78-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 90, name: "Max" }
+    { homekitTopLevel: 100, miLevel: 90, name: "Max" },
   ],
   gen2: [
     // 0%      = Off / Aus
@@ -25,7 +25,7 @@ module.exports = {
     // 61-75%  = "Turbo / Stark"
     { homekitTopLevel: 75, miLevel: 75, name: "Turbo" },
     // 76-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 100, name: "Max" }
+    { homekitTopLevel: 100, miLevel: 100, name: "Max" },
   ],
   gen3: [
     // 0%      = Off / Aus
@@ -37,7 +37,7 @@ module.exports = {
     // 61-77%  = "Turbo / Stark"
     { homekitTopLevel: 77, miLevel: 103, name: "Turbo" },
     // 78-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 104, name: "Max" }
+    { homekitTopLevel: 100, miLevel: 104, name: "Max" },
   ],
   // S5-Max (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
   gen4: [
@@ -52,7 +52,7 @@ module.exports = {
     // 61-77%  = "Turbo / Stark"
     { homekitTopLevel: 77, miLevel: 103, name: "Turbo" },
     // 78-100% = "Full Speed / Max Speed / Max"
-    { homekitTopLevel: 100, miLevel: 104, name: "Max" }
+    { homekitTopLevel: 100, miLevel: 104, name: "Max" },
   ],
   // S5-Max + Custom (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/110)
   "gen4+custom": [
@@ -70,5 +70,5 @@ module.exports = {
     { homekitTopLevel: 90, miLevel: 104, name: "Max" },
     // 91-100% = "Custom"
     { homekitTopLevel: 100, miLevel: 106, name: "Custom" },
-  ]
+  ],
 };

--- a/models/watermodes.js
+++ b/models/watermodes.js
@@ -1,8 +1,8 @@
-'use strict';
+"use strict";
 
 module.exports = {
   // S5-Max (https://github.com/nicoh88/homebridge-xiaomi-roborock-vacuum/issues/79#issuecomment-576246934)
-  gen1: [ 
+  gen1: [
     // 0%      = Off
     { homekitTopLevel: 0, miLevel: 200, name: "Off" },
     // 1-35%   = "Light"
@@ -10,6 +10,6 @@ module.exports = {
     // 36-70%  = "Medium"
     { homekitTopLevel: 70, miLevel: 202, name: "Medium" },
     // 71-100% = "High"
-    { homekitTopLevel: 100, miLevel: 203, name: "Hight" }
-  ]
+    { homekitTopLevel: 100, miLevel: 203, name: "Hight" },
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -36,9 +36,12 @@
   },
   "dependencies": {
     "miio-nicoh88": ">=0.1.0",
-    "semver": "^7.1.2"
+    "semver": "^7.3.2"
   },
   "optionalDependencies": {
     "system-sleep": "^1.3.6"
+  },
+  "devDependencies": {
+    "prettier": "^2.0.5"
   }
 }


### PR DESCRIPTION
As the number of maintainers is growing 🎊 and in order to maintain some sense of the code. I think it makes sense to have a linter/formatter that will unify the code style in this project. I'm installing `prettier` as some sort of `standard` to help us with maintaining the style. 

We'll investigate in the future ways to block PRs unless prettier is successful (it should be easy with Github workflows/Travis CI or any other automated workflows).